### PR TITLE
Switch to virtual/synthetic microscope config

### DIFF
--- a/src/navigate/config/configuration.yaml
+++ b/src/navigate/config/configuration.yaml
@@ -1,409 +1,133 @@
-# Only one microscope can be active in the GUI at a time, but all microscopes will be accessible
 microscopes:
-  Mesoscale:
-    daq:
+  virtual_microscope:
+    camera:
+      defect_correct_mode: 2.0
+      delay: 5.0
+      flip_x: False
+      flip_y: False
       hardware:
-        type: NI
-
-      # NI PCIe-1073 Chassis with PXI-6259 and PXI-6733 DAQ Boards.
-      # Sampling rate in Hz
-      sample_rate: 100000
-
-      # triggers
-      master_trigger_out_line: PXI6259/port0/line1
-      camera_trigger_out_line: /PXI6259/ctr0
-      trigger_source: /PXI6259/PFI0
-
-      # Digital Laser Outputs
-      laser_port_switcher: PXI6733/port0/line0
+        camera_connection: 1
+        serial_number: 1
+        type: Synthetic
+      settle_down: 5.0
+      supported_channel_count: 5
+    daq:
+      camera_trigger_out_line: virtual/2
+      hardware:
+        type: Synthetic
+      laser_port_switcher: virtual/4
       laser_switch_state: False
-
-    camera:
-      hardware:
-        type: HamamatsuOrca
-        serial_number: 302158
-        camera_connection: PMPCIECam00 #Photometrics only
-      defect_correct_mode: 2.0
-      delay: 1.0 #ms
-      settle_down: 0.0 #ms
-      flip_x: False
-      flip_y: False
-    remote_focus:
-      hardware:
-        name: daq
-        type: NI
-        channel: PXI6259/ao2
-        min: 0
-        max: 5
-        port:
-        baudrate:
-    galvo:
-      -
-        hardware:
-          type: NI
-          channel: PXI6259/ao0
-          min: -5
-          max: 5
-        waveform: sine
-        phase: 1.57079 # pi/2
-    filter_wheel:
-      hardware:
-        type: SutterFilterWheel
-        wheel_number: 1
-        port: 
-        baudrate: 0
-      filter_wheel_delay: .030 # in seconds
-      available_filters:
-        Empty-Alignment: 0
-        GFP - FF01-515/30-32: 1
-        RFP - FF01-595/31-32: 2
-        Far-Red - BLP01-647R/31-32: 3
-        Blocked1: 4
-        Blocked2: 5
-        Blocked3: 6
-        Blocked4: 7
-        Blocked5: 8
-        Blocked6: 9
-    stage:
-      hardware:
-        -
-          type: PI
-          serial_number: 119060508
-          axes: [x, y, z, theta, f]
-          axes_mapping: [1, 2, 3, 4, 5]
-          feedback_alignment: 
-          device_units_per_mm: 
-          volts_per_micron: 
-          min: 0.0
-          max: 5.0
-          distance_threshold: 5.0
-          settle_duration_ms: 18.0
-          controllername: 'C-884'
-          stages: L-509.20DG10 L-509.40DG10 L-509.20DG10 M-060.DG M-406.4PD NOSTAGE
-          refmode: FRF FRF FRF FRF FRF FRF
-          port: 
-          baudrate: 0
-          timeout: 0.25
-
-      joystick_axes: [x, y, z]
-      # coupled_axes:
-      #   z: f
-      x_max: 100000
-      x_min: -100000
-      y_max: 100000
-      y_min: -100000
-      z_max: 100000
-      z_min: -100000
-      f_max: 100000
-      f_min: -100000
-      theta_max: 360
-      theta_min: 0
-
-      x_offset: 0
-      y_offset: 0
-      z_offset: 0
-      theta_offset: 0
-      f_offset: 0
-
-      flip_x: False
-      flip_y: False
-      flip_z: False
-      flip_f: False
-
-    zoom:
-      hardware:
-        type: DynamixelZoom
-        servo_id: 1
-        port: COM9
-        baudrate: 100000
-      position:
-        0.63x: 0
-        1x: 627
-        2x: 1711
-        3x: 2301
-        4x: 2710
-        5x: 3079
-        6x: 3383
-      pixel_size:
-        0.63x: 9.7
-        1x: 6.38
-        2x: 3.14
-        3x: 2.12
-        4x: 1.609
-        5x: 1.255
-        6x: 1.044
-      stage_positions:
-        BABB:
-          f:
-            0.63x: 0
-            1x: 1
-            2x: 2
-            3x: 3
-            4x: 4
-            5x: 5
-            6x: 6
-    shutter:
-      hardware:
-        type: NI
-        channel: PXI6259/port0/line0
-        min: 0
-        max: 5
-    laser:
-      # Omicron LightHub Ultra
-      # 488 and 640 are LuxX+ Lasers
-      # 561 is a Coherent OBIS Laser
-      # Digital Laser Outputs
-      - wavelength: 488
-        onoff:
-          hardware:
-            type: NI
-            channel: PXI6733/port0/line2
-            min: 0
-            max: 5
-        power:
-          hardware:
-            type: NI
-            channel: PXI6733/ao0
-            min: 0
-            max: 5
-        type: LuxX
-      - wavelength: 562
-        onoff:
-          hardware:
-            type: NI
-            channel: PXI6733/port0/line3
-            min: 0
-            max: 5
-        power:
-          hardware:
-            type: NI
-            channel: PXI6733/ao1
-            min: 0
-            max: 5
-        type: Obis
-      - wavelength: 642
-        onoff:
-          hardware:
-            type: NI
-            channel: PXI6733/port0/line4
-            min: 0
-            max: 5
-        power:
-          hardware:
-            type: NI
-            channel: PXI6733/ao2
-            min: 0
-            max: 5
-        type: LuxX
-  Nanoscale:
-    daq:
-      hardware:
-        type: NI
-
-      # NI PCIe-1073 Chassis with PXI-6259 and PXI-6733 DAQ Boards.
-      # Sampling rate in Hz
+      master_trigger_out_line: virtual/1
       sample_rate: 100000
-
-      # triggers
-      master_trigger_out_line: PXI6259/port0/line1
-      camera_trigger_out_line: /PXI6259/ctr0
-      trigger_source: /PXI6259/PFI0
-
-      # Digital Laser Outputs
-      laser_port_switcher: PXI6733/port0/line0
-      laser_switch_state: True
-
-    camera:
+      trigger_source: virtual/3
+    filter_wheel:
+      available_filters:
+        Far-Red: 2
+        Green: 0
+        Red: 1
+      filter_wheel_delay: 0.03
       hardware:
-        type: HamamatsuOrca
-        serial_number: 302352
-        camera_connection: PMPCIECam00 #Photometrics only
-      defect_correct_mode: 2.0
-      delay: 1.0 #ms
-      settle_down: 0 #ms
-      flip_x: False
-      flip_y: False
+        baudrate: 9600
+        name: FW1
+        port: 1
+        type: Synthetic
+        wheel_number: 1
+    galvo:
+       -
+        hardware:
+          axis: A
+          channel: virtual/ao0
+          max: 0.0
+          min: -10.0
+          type: Synthetic
+        phase: 0.0
+        waveform: sine
+    laser:
+       -
+        onoff:
+          hardware:
+            axis: NA
+            channel: virutla/do1
+            max: 5.0
+            min: 0.0
+            type: Synthetic
+        power:
+          hardware:
+            axis: NA
+            channel: virtual/ao1
+            max: 5.0
+            min: 0.0
+            type: Synthetic
+        wavelength: 488
+    mirror:
+      hardware:
+        flat_path: D:\Path\to\wcs\file
+        type: Synthetic
+      n_modes: 32
     remote_focus:
       hardware:
-        type: NI
-        channel: PXI6259/ao3
-        min: -0.7
-        max: 0.7
-        port: 
-        baudrate: 0
-    galvo:
-      -
-        hardware:
-          type: NI
-          channel: PXI6259/ao1
-          min: -5
-          max: 5
-        waveform: sine
-        phase: 1.57079 # pi/2
-    filter_wheel:
+        axis: NA
+        baudrate: 9600
+        channel: virtual/ao2
+        max: 10.0
+        min: -10.0
+        port: COM1
+        type: Synthetic
+    shutter:
       hardware:
-        type: SutterFilterWheel
-        wheel_number: 2
-        port:
-        baudrate:
-      filter_wheel_delay: .030 # in seconds
-      available_filters:
-        Empty-Alignment: 0
-        GFP - FF01-515/30-32: 1
-        RFP - FF01-595/31-32: 2
-        Far-Red - BLP01-647R/31-32: 3
-        Blocked1: 4
-        Blocked2: 5
-        Blocked3: 6
-        Blocked4: 7
-        Blocked5: 8
-        Blocked6: 9
+        axis: NA
+        channel: virtual\d01
+        max: 5.0
+        min: 0.0
+        port: COM2
+        type: Synthetic
     stage:
-      hardware:
-        -
-          type: PI
-          serial_number: 119060508
-          axes: [x, y, z, theta]
-          axes_mapping: [1, 2, 3, 4]
-          feedback_alignment: 
-          device_units_per_mm: 
-          volts_per_micron: 
-          min: 0.0
-          max: 5.0
-          distance_threshold: 5.0
-          settle_duration_ms: 18.0
-          controllername: 'C-884'
-          stages: L-509.20DG10 L-509.40DG10 L-509.20DG10 M-060.DG M-406.4PD NOSTAGE
-          refmode: FRF FRF FRF FRF FRF FRF
-          port: 
-          baudrate: 0
-          timeout: 0.25
-        -
-          type: Thorlabs
-          serial_number: 74000375
-          axes: [f]
-          axes_mapping: [1]
-          feedback_alignment: 
-          device_units_per_mm: 
-          volts_per_micron: 
-          min: 0.0
-          max: 5.0
-          distance_threshold: 5.0
-          settle_duration_ms: 18.0
-          controllername: 
-          stages: 
-          refmode: 
-          port: 
-          baudrate: 0
-          timeout: 0.25
-
-      joystick_axes: [x, y, z]
-      # coupled_axes:
-      #   z: f
-      x_max: 100000
-      x_min: -100000
-      y_max: 100000
-      y_min: -100000
-      z_max: 100000
-      z_min: -100000
-      f_max: 100000
-      f_min: -100000
-      theta_max: 360
-      theta_min: 0
-
-      x_offset: 1
-      y_offset: 1
-      z_offset: 1
-      theta_offset: 0
-      f_offset: 0
+      f_max: 10000.0
+      f_min: -10000.0
+      f_offset: 0.0
+      flip_f: False
       flip_x: False
       flip_y: False
       flip_z: False
-      flip_f: False
-
+      hardware:
+        -
+          axes: [x, y, z, f, theta]
+          axes_mapping: [X, M, Y, F, R]
+          baudrate: 0
+          controllername: 
+          device_units_per_mm: 1000.25
+          distance_threshold: 5.0
+          feedback_alignment: [90, 90, 90, 90, 90]
+          max: 4.6
+          min: 0.0
+          port: COM3
+          refmode: 
+          serial_number: 
+          settle_duration_ms: 20.0
+          stages: 
+          timeout: 0.25
+          type: Synthetic
+          volts_per_micron: 0.1*x+0.05
+      joystick_axes: [x, y, z, f, theta]
+      theta_max: 360.0
+      theta_min: 0.0
+      theta_offset: 0.0
+      x_max: 10000.0
+      x_min: -10000.0
+      x_offset: 0.0
+      y_max: 10000.0
+      y_min: -10000.0
+      y_offset: 0.0
+      z_max: 6000.0
+      z_min: -10000.0
+      z_offset: 0.0
     zoom:
       hardware:
-        type: synthetic
-        servo_id:
-        port:
-        baudrate:
-      position:
-        N/A: 0
+        baudrate: 9600
+        port: COM4
+        servo_id: NA
+        type: Synthetic
       pixel_size:
-        N/A: 0.167
-      stage_positions:
-        BABB:
-          f:
-            N/A: 0
-    shutter:
-      hardware:
-        name: daq
-        type: NI
-        channel: PXI6259/port2/line0
-        min: 0.0
-        max: 5.0
-    laser:
-      # Omicron LightHub Ultra
-      # 488 and 640 are LuxX+ Lasers
-      # 561 is a Coherent OBIS Laser
-      # Digital Laser Outputs
-      - wavelength: 488
-        onoff:
-          hardware:
-            type: NI
-            channel: PXI6733/port0/line2
-            min: 0
-            max: 5
-        power:
-          hardware:
-            type: NI
-            channel: PXI6733/ao0
-            min: 0
-            max: 5
-        type: LuxX
-      - wavelength: 562
-        onoff:
-          hardware:
-            type: NI
-            channel: PXI6733/port0/line3
-            min: 0
-            max: 5
-        power:
-          hardware:
-            type: NI
-            channel: PXI6733/ao1
-            min: 0
-            max: 5
-        type: Obis
-      - wavelength: 642
-        onoff:
-          hardware:
-            type: NI
-            channel: PXI6733/port0/line4
-            min: 0
-            max: 5
-        power:
-          hardware:
-            type: NI
-            channel: PXI6733/ao2
-            min: 0
-            max: 5
-        type: LuxX
-
-gui:
-  channels:
-    count: 5
-
-BDVParameters:
-# The following parameters are used to configure the BigDataViewer
-  # visualization. See the BigDataViewer documentation for more details.
-  # https://imagej.net/BigDataViewer
-  shear:
-    shear_data: True
-    shear_dimension: YZ # XZ, YZ, or XY
-    shear_angle: 45
-  rotate:
-    rotate_data: False
-    X: 0
-    Y: 0
-    Z: 0
+        1x: 6.5
+      position:
+        1x: 1.0


### PR DESCRIPTION
Overhauled configuration to replace hardware-specific Mesoscale/Nanoscale entries with a unified virtual_microscope using Synthetic/virtual hardware. Removed NI, Hamamatsu, Sutter, PI, and Thorlabs-specific settings and consolidated DAQ, camera, filter_wheel, galvo, shutter, laser, stage, and zoom into virtual defaults for simulation/testing. Adjusted camera delay/settle values, simplified filter mappings, added virtual trigger/laser channels, normalized stage/joystick limits, and removed legacy GUI/BDVParameters sections.