### PR TITLE
Make resolution changes cancellable from Stop Stage

### DIFF
--- a/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md
+++ b/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md
@@ -504,7 +504,7 @@ git log --oneline origin/develop..HEAD
 
 Verify comments are brief and limited to the four non-obvious constraints in Global Constraints. Commit checkbox progress with `docs: record issue 486 core implementation`.
 
-- [ ] **Step 4: Push and open the core PR**
+- [x] **Step 4: Push and open the core PR**
 
 Push `kdean/issue-486-stop-resolution-change` and open a draft PR targeting `develop`. The body links the design and plan, summarizes focused and broader test evidence, records Xvfb/Aqua limitations, requests the designated reviewer if discoverable, and includes `Closes #486`.
 

--- a/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md
+++ b/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md
@@ -459,7 +459,7 @@ git commit -m "fix: terminate cancelled resolution features safely" -m \
 - Consumes: Tasks 1-4.
 - Produces: a mergeable core branch that independently prevents collision-causing continuation.
 
-- [ ] **Step 1: Run core formatting and lint**
+- [x] **Step 1: Run core formatting and lint**
 
 ```bash
 ruff check src/navigate/model/model.py src/navigate/model/microscope.py \
@@ -482,7 +482,7 @@ black --check src/navigate/model/model.py src/navigate/model/microscope.py \
   test/controller/sub_controllers/test_stages.py
 ```
 
-- [ ] **Step 2: Run the relevant broader test set**
+- [x] **Step 2: Run the relevant broader test set**
 
 ```bash
 PYTHONPATH=src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' -q \
@@ -494,7 +494,7 @@ PYTHONPATH=src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' -
 
 Do not run the Tk-backed `stage_controller` package fixture locally; its direct-handler test has no fixture dependency.
 
-- [ ] **Step 3: Inspect the core diff and commit plan progress**
+- [x] **Step 3: Inspect the core diff and commit plan progress**
 
 ```bash
 git diff origin/develop --check

--- a/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md
+++ b/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md
@@ -141,7 +141,7 @@ git commit -m "fix: dispatch stage stops without GUI delay"
 - Consumes: `threading.Event`, existing stage `move_absolute`, `move_axis_absolute`, `stop`, and `verify_abs_position` contracts.
 - Produces: `Microscope.move_stage_offset(former_microscope=None, cancel_event=None) -> bool`; `Microscope.move_stage(..., cancel_event=None) -> bool`; `Microscope.stop_stage(stopped_stage_ids=None) -> list[str]`.
 
-- [ ] **Step 1: Write failing movement tests with literal expected order**
+- [x] **Step 1: Write failing movement tests with literal expected order**
 
 ```python
 def test_move_stage_stops_before_second_device_after_cancellation():
@@ -173,7 +173,7 @@ def test_stop_stage_attempts_each_unique_device_after_error():
 
 The test helpers implement only stage-driver behavior and live in the test module.
 
-- [ ] **Step 2: Run the movement tests and verify RED**
+- [x] **Step 2: Run the movement tests and verify RED**
 
 Run:
 
@@ -184,7 +184,7 @@ PYTHONPATH=src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' -
 
 Expected: current signatures reject `cancel_event` and stopping aborts on the first error or repeats a shared stage.
 
-- [ ] **Step 3: Extend the existing microscope methods**
+- [x] **Step 3: Extend the existing microscope methods**
 
 ```python
 def _movement_cancelled(cancel_event: Optional[threading.Event]) -> bool:
@@ -193,11 +193,11 @@ def _movement_cancelled(cancel_event: Optional[threading.Event]) -> bool:
 
 Check this helper before and after each blocking move. Return `False` on cancellation. Extend `stop_stage` with a caller-provided set of attempted stage object IDs, add IDs before invoking `stop()`, catch and log each exception, and return error strings after attempting all devices.
 
-- [ ] **Step 4: Complete Numpydoc and run focused tests**
+- [x] **Step 4: Complete Numpydoc and run focused tests**
 
 Document the cancellation-event ownership, blocking behavior, Boolean return, deduplication set, best-effort stop semantics, and returned errors. Run the Step 2 command and the existing microscope/model resolution test; expected: pass.
 
-- [ ] **Step 5: Commit the movement primitive**
+- [x] **Step 5: Commit the movement primitive**
 
 ```bash
 git add src/navigate/model/microscope.py test/model/test_resolution_change.py

--- a/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md
+++ b/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md
@@ -59,7 +59,7 @@
 - Consumes: existing `StageController.parent_controller.execute(command)` and `SynchronizedThreadPool.createThread(resourceName, target)`.
 - Produces: `StageController.stop_button_handler()` dispatches `"stop_stage"` synchronously; `Controller.execute("resolution")` submits without joining; `Controller._stop_stage_safely() -> None` retries transient proxy contention.
 
-- [ ] **Step 1: Write failing controller tests**
+- [x] **Step 1: Write failing controller tests**
 
 ```python
 def test_stop_button_handler_dispatches_immediately():
@@ -83,7 +83,7 @@ def test_stop_stage_retries_proxy_contention(controller):
     assert controller.model.stop_stage.call_count == 2
 ```
 
-- [ ] **Step 2: Run the focused tests and verify RED**
+- [x] **Step 2: Run the focused tests and verify RED**
 
 Run:
 
@@ -96,7 +96,7 @@ PYTHONPATH=src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' -
 
 Expected: failures show the Tk debounce, worker `join()`, and missing retry helper.
 
-- [ ] **Step 3: Implement the minimal controller fixes**
+- [x] **Step 3: Implement the minimal controller fixes**
 
 ```python
 def stop_button_handler(self, *args: Iterable) -> None:
@@ -117,11 +117,11 @@ def _stop_stage_safely(self) -> None:
 
 Use `_stop_stage_safely` as the `"stop_stage"` thread target and remove the resolution worker assignment and `join()`.
 
-- [ ] **Step 4: Run the focused tests and verify GREEN**
+- [x] **Step 4: Run the focused tests and verify GREEN**
 
 Run the Step 2 command. Expected: all three pass without constructing Tk.
 
-- [ ] **Step 5: Commit the direct-dispatch slice**
+- [x] **Step 5: Commit the direct-dispatch slice**
 
 ```bash
 git add src/navigate/controller/controller.py \

--- a/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md
+++ b/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md
@@ -1,0 +1,715 @@
+# Issue 486 Resolution-Change Cancellation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Stop Stage cancel an in-progress resolution change, immediately stop every participating stage, prevent later motion, and offer an explicit keep-or-return recovery choice.
+
+**Architecture:** The model owns one private resolution-change task with a cancellation event and terminal event payload. Manual resolution updates run in a model-owned worker so ObjectInSubprocess remains available for Stop Stage; feature-driven updates register their signal thread with the same lifecycle. A stacked recovery change consumes the terminal cancellation event, presents a `PopUp`, and starts any requested return as a second cancellable model worker.
+
+**Tech Stack:** Python 3.9, `threading`, Tk/ttk, Navigate's `Model`/`Microscope`/controller event queue, pytest, Ruff, Black.
+
+## Global Constraints
+
+- Stop Stage records cancellation before attempting any hardware stop.
+- Every unique stage device in the former and target microscopes receives a stop attempt; one driver failure cannot skip the rest.
+- No Tk `after()` debounce or controller-side resolution-worker `join()` may delay Stop Stage.
+- Cancellation is checked before and after every blocking resolution-induced stage movement.
+- Cancelled resolution changes do not restart live or customized acquisition.
+- Return never begins implicitly; Close and Escape mean Keep Current Position.
+- Return moves to the literal pre-movement coordinates, keeps the selected microscope/resolution, preserves stage limits, and is itself cancellable.
+- Local focused tests must not instantiate Aqua Tk. Native GUI checks run on Windows CI or Linux X11 Tk under `xvfb-run -a`.
+- Comments explain only non-obvious safety ordering, proxy retry, and worker-acknowledgement constraints.
+- Python tests use `PYTHONPATH=src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts=''`.
+
+## File Structure
+
+- Create `src/navigate/model/resolution_change.py`: private task state shared by model resolution, stop, and recovery paths.
+- Modify `src/navigate/model/microscope.py`: cooperative movement cancellation and deduplicated best-effort stage stopping.
+- Modify `src/navigate/model/model.py`: task ownership, asynchronous manual resolution update, terminal events, cancellation-safe acquisition cleanup, and recovery commands.
+- Modify `src/navigate/model/features/update_setting.py`: keep customized resolution changes inside the same cancellable lifecycle.
+- Modify `src/navigate/controller/controller.py`: nonblocking resolution submission, reliable Stop Stage proxy retries, and recovery event handling.
+- Modify `src/navigate/controller/sub_controllers/stages.py`: remove the Stop Stage debounce.
+- Create `src/navigate/view/popups/resolution_change_popup.py`: two-choice modal recovery view.
+- Create `test/model/test_resolution_change.py`: focused task, stop-order, async, and return tests using blocking stage doubles.
+- Modify `test/model/test_model.py`: preserve successful-resolution behavior and add acquisition cancellation coverage.
+- Modify `test/controller/test_controller.py`: nonblocking submission, proxy retry, event deduplication, and recovery dispatch tests without Tk.
+- Modify `test/controller/sub_controllers/test_stages.py`: direct Stop Stage dispatch test without using the Tk fixture.
+- Create `test/view/popups/test_resolution_change_popup.py`: callback semantics tested through the real popup methods without constructing Tk widgets locally.
+- Modify `docs/source/05_reference/_autosummary/navigate.model.model.Model.rst`: synchronize changed user-callable model contracts when needed.
+
+## Reuse Analysis
+
+- Closest existing symbols: `Controller.execute("resolution")`, `Model.run_command("update_setting", "resolution")`, `Model.change_resolution`, `Microscope.move_stage_offset`, `Microscope.move_stage`, `Controller.stop_stage`, `Model.stop_stage`, `Microscope.stop_stage`, `Controller.sloppy_stop`, the model event queue, and `PopUp`.
+- Decision: extend the existing resolution, stage-movement, Stop Stage, event, and popup lifecycles. Keep task coordination private to the model.
+- Rejected alternative: a controller-only cancellation flag would not cross ObjectInSubprocess safely and would leave feature-driven changes and multi-device movement unprotected.
+- Rejected alternative: a second emergency pipe would duplicate device ownership and require a new thread-safety contract for every stage driver.
+- Documentation updates: full Numpydoc for changed public method signatures and returns, existing model autosummary synchronization, the committed design, and this executable plan.
+
+---
+
+### Task 1: Direct GUI safety dispatch
+
+**Files:**
+- Modify: `test/controller/sub_controllers/test_stages.py`
+- Modify: `test/controller/test_controller.py`
+- Modify: `src/navigate/controller/sub_controllers/stages.py`
+- Modify: `src/navigate/controller/controller.py`
+
+**Interfaces:**
+- Consumes: existing `StageController.parent_controller.execute(command)` and `SynchronizedThreadPool.createThread(resourceName, target)`.
+- Produces: `StageController.stop_button_handler()` dispatches `"stop_stage"` synchronously; `Controller.execute("resolution")` submits without joining; `Controller._stop_stage_safely() -> None` retries transient proxy contention.
+
+- [ ] **Step 1: Write failing controller tests**
+
+```python
+def test_stop_button_handler_dispatches_immediately():
+    controller = SimpleNamespace(parent_controller=MagicMock())
+    StageController.stop_button_handler(controller)
+    controller.parent_controller.execute.assert_called_once_with("stop_stage")
+
+
+def test_execute_resolution_does_not_join_worker(controller):
+    worker = MagicMock()
+    controller.threads_pool.createThread = MagicMock(return_value=worker)
+    controller.execute("resolution", controller.menu_controller.resolution_value.get())
+    worker.join.assert_not_called()
+
+
+def test_stop_stage_retries_proxy_contention(controller):
+    controller.model.stop_stage = MagicMock(
+        side_effect=[RuntimeError("pipe busy"), None]
+    )
+    controller._stop_stage_safely()
+    assert controller.model.stop_stage.call_count == 2
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+PYTHONPATH=src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' -q \
+  test/controller/sub_controllers/test_stages.py::test_stop_button_handler_dispatches_immediately \
+  test/controller/test_controller.py::test_execute_resolution_does_not_join_worker \
+  test/controller/test_controller.py::test_stop_stage_retries_proxy_contention
+```
+
+Expected: failures show the Tk debounce, worker `join()`, and missing retry helper.
+
+- [ ] **Step 3: Implement the minimal controller fixes**
+
+```python
+def stop_button_handler(self, *args: Iterable) -> None:
+    """Request an immediate stop for all stages."""
+    self.parent_controller.execute("stop_stage")
+
+
+def _stop_stage_safely(self) -> None:
+    """Retry a stage stop rejected by transient model-proxy contention."""
+    while True:
+        try:
+            self.model.stop_stage()
+            return
+        except RuntimeError:
+            # A safety stop must not disappear in the thread-pool exception handler.
+            time.sleep(0.001)
+```
+
+Use `_stop_stage_safely` as the `"stop_stage"` thread target and remove the resolution worker assignment and `join()`.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run the Step 2 command. Expected: all three pass without constructing Tk.
+
+- [ ] **Step 5: Commit the direct-dispatch slice**
+
+```bash
+git add src/navigate/controller/controller.py \
+  src/navigate/controller/sub_controllers/stages.py \
+  test/controller/test_controller.py \
+  test/controller/sub_controllers/test_stages.py
+git commit -m "fix: dispatch stage stops without GUI delay"
+```
+
+### Task 2: Cooperative microscope movement cancellation
+
+**Files:**
+- Create: `test/model/test_resolution_change.py`
+- Modify: `src/navigate/model/microscope.py`
+
+**Interfaces:**
+- Consumes: `threading.Event`, existing stage `move_absolute`, `move_axis_absolute`, `stop`, and `verify_abs_position` contracts.
+- Produces: `Microscope.move_stage_offset(former_microscope=None, cancel_event=None) -> bool`; `Microscope.move_stage(..., cancel_event=None) -> bool`; `Microscope.stop_stage(stopped_stage_ids=None) -> list[str]`.
+
+- [ ] **Step 1: Write failing movement tests with literal expected order**
+
+```python
+def test_move_stage_stops_before_second_device_after_cancellation():
+    cancel_event = threading.Event()
+    calls = []
+    first = RecordingStage("first", calls, cancel_event_on_move=cancel_event)
+    second = RecordingStage("second", calls)
+    microscope = make_microscope_with_stages(first, second)
+
+    assert microscope.move_stage(
+        {"x_abs": 10.0, "z_abs": 20.0},
+        wait_until_done=True,
+        cancel_event=cancel_event,
+    ) is False
+    assert calls == [("move", "first", {"x_abs": 10.0})]
+
+
+def test_stop_stage_attempts_each_unique_device_after_error():
+    calls = []
+    shared = RecordingStage("shared", calls, stop_error=RuntimeError("failed"))
+    other = RecordingStage("other", calls)
+    microscope = make_microscope_with_stages(shared, shared, other)
+
+    errors = microscope.stop_stage()
+
+    assert calls == [("stop", "shared"), ("stop", "other")]
+    assert len(errors) == 1
+```
+
+The test helpers implement only stage-driver behavior and live in the test module.
+
+- [ ] **Step 2: Run the movement tests and verify RED**
+
+Run:
+
+```bash
+PYTHONPATH=src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' -q \
+  test/model/test_resolution_change.py -k 'move_stage or stop_stage'
+```
+
+Expected: current signatures reject `cancel_event` and stopping aborts on the first error or repeats a shared stage.
+
+- [ ] **Step 3: Extend the existing microscope methods**
+
+```python
+def _movement_cancelled(cancel_event: Optional[threading.Event]) -> bool:
+    return cancel_event is not None and cancel_event.is_set()
+```
+
+Check this helper before and after each blocking move. Return `False` on cancellation. Extend `stop_stage` with a caller-provided set of attempted stage object IDs, add IDs before invoking `stop()`, catch and log each exception, and return error strings after attempting all devices.
+
+- [ ] **Step 4: Complete Numpydoc and run focused tests**
+
+Document the cancellation-event ownership, blocking behavior, Boolean return, deduplication set, best-effort stop semantics, and returned errors. Run the Step 2 command and the existing microscope/model resolution test; expected: pass.
+
+- [ ] **Step 5: Commit the movement primitive**
+
+```bash
+git add src/navigate/model/microscope.py test/model/test_resolution_change.py
+git commit -m "fix: make resolution stage moves cancellable" -m \
+  "Reuse analysis: extended Microscope.move_stage, move_stage_offset, and stop_stage. A second movement executor would duplicate stage mapping, limit enforcement, and device ownership."
+```
+
+### Task 3: Model-owned resolution lifecycle and hardware-stop ordering
+
+**Files:**
+- Create: `src/navigate/model/resolution_change.py`
+- Modify: `test/model/test_resolution_change.py`
+- Modify: `src/navigate/model/model.py`
+
+**Interfaces:**
+- Consumes: Task 2 cancellation-aware movement and best-effort stop methods.
+- Produces: private `_ResolutionChangeTask`; `Model._begin_resolution_change(resolution_value)`, `_perform_resolution_change(task)`, `_finish_resolution_change(task, succeeded)`, `_start_resolution_setting_update()`, cancellation-aware `Model.stop_stage(cancel_resolution_change=True)`, and `Model.move_stage(..., cancel_event=None) -> bool`; `Model.change_resolution(resolution_value) -> bool` remains the synchronous public entry point.
+
+- [ ] **Step 1: Write failing task and stop-order tests**
+
+```python
+def test_stop_stage_records_cancellation_before_hardware_stop():
+    observed = []
+    model, task = make_model_with_resolution_task()
+    model.active_microscope.stop_stage = lambda *args, **kwargs: observed.append(
+        task.cancel_event.is_set()
+    ) or []
+
+    model.stop_stage()
+
+    assert observed == [True]
+
+
+def test_resolution_worker_cannot_start_second_stage_after_stop():
+    model, first, second = make_blocking_resolution_model()
+    assert model._start_resolution_setting_update() is True
+    assert first.move_started.wait(1.0)
+    worker = model._resolution_change_task.worker
+
+    model.stop_stage()
+    worker.join(1.0)
+
+    assert first.stop_called.is_set()
+    assert second.move_started.is_set() is False
+
+
+def test_terminate_cancels_and_joins_resolution_worker():
+    model, first, _ = make_blocking_resolution_model()
+    model._start_resolution_setting_update()
+    assert first.move_started.wait(1.0)
+    worker = model._resolution_change_task.worker
+
+    model.terminate()
+
+    assert first.stop_called.is_set()
+    assert worker.is_alive() is False
+```
+
+- [ ] **Step 2: Run the task tests and verify RED**
+
+Run:
+
+```bash
+PYTHONPATH=src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' -q \
+  test/model/test_resolution_change.py \
+  -k 'records_cancellation or worker_cannot or terminate_cancels'
+```
+
+Expected: the private lifecycle is absent and current Stop Stage cannot cancel the worker.
+
+- [ ] **Step 3: Add the private task record and model initialization**
+
+```python
+@dataclass
+class _ResolutionChangeTask:
+    task_id: int
+    resolution_value: str
+    former_microscope_name: str
+    target_microscope_name: str
+    cancel_event: threading.Event = field(default_factory=threading.Event)
+    state: str = "changing"
+    worker: Optional[threading.Thread] = None
+    previous_position: Optional[dict[str, float]] = None
+    stopped_position: Optional[dict[str, float]] = None
+    stop_errors: list[str] = field(default_factory=list)
+```
+
+Initialize a lock, counter, and optional current task in `Model.__init__`. `_begin_resolution_change` rejects an existing active task with a model warning event.
+
+- [ ] **Step 4: Refactor successful resolution movement behind the task**
+
+Move the physical body of `change_resolution` into `_perform_resolution_change(task)`. Capture the target stage position immediately before the first resolution-induced stage move, pass `task.cancel_event` through Task 2 methods, and check cancellation before zoom, offset, final stage update, waveform work, and acquisition restart. Extend `Model.move_stage` with an optional `cancel_event` that forwards to `Microscope.move_stage`. The public `change_resolution` creates and finishes a synchronous task and returns success.
+
+```python
+def _perform_resolution_change(self, task: _ResolutionChangeTask) -> bool:
+    if task.cancel_event.is_set():
+        return False
+    former_microscope = task.former_microscope_name
+    if task.target_microscope_name != former_microscope:
+        self.get_active_microscope()
+        task.previous_position = {
+            key.replace("_pos", "_abs"): value
+            for key, value in self.get_stage_position().items()
+        }
+        if not self.active_microscope.move_stage_offset(
+            former_microscope, cancel_event=task.cancel_event
+        ):
+            return False
+    if task.cancel_event.is_set():
+        return False
+    # Existing zoom-offset logic continues here and passes task.cancel_event.
+```
+
+- [ ] **Step 5: Make manual setting updates model-owned and asynchronous**
+
+Extract the existing `run_command("update_setting")` body to `_update_setting(command, resolution_task=None)`. For `"resolution"`, create the task before starting a `ThreadWithWarning` worker and return immediately. For other settings such as `"galvo"`, retain synchronous behavior. On cancellation set acquisition stop flags, release a paused data thread, avoid waveform publication/restart, and complete the task as cancelled.
+
+```python
+elif command == "update_setting":
+    if args[0] == "resolution":
+        self._start_resolution_setting_update()
+        return
+    self._update_setting(args[0])
+```
+
+- [ ] **Step 6: Implement ordered best-effort Stop Stage**
+
+Set the active task's cancellation event and state under its lock before calling any device. Stop former, target, and active microscopes with one shared set of attempted stage IDs. Record errors, read the actual active position, update configuration, and publish `update_stage`. Do not wait for the worker before issuing stops. The worker publishes `resolution_change_cancelled` only after reaching terminal state. Extend `Model.terminate` to set cancellation, issue the same stage stop, and join the active worker before microscope teardown.
+
+```python
+def stop_stage(self, *, cancel_resolution_change: bool = True) -> None:
+    task = self._resolution_change_task
+    if cancel_resolution_change and task is not None:
+        # Prevent the worker from scheduling another move before stopping hardware.
+        task.cancel_event.set()
+        task.state = "cancel_requested"
+    attempted_stage_ids = set()
+    stop_errors = []
+    for microscope_name in self._stage_stop_microscope_names(task):
+        stop_errors.extend(
+            self.microscopes[microscope_name].stop_stage(attempted_stage_ids)
+        )
+    if task is not None:
+        task.stop_errors.extend(stop_errors)
+    stopped_position = self.get_stage_position()
+    self.event_queue.put(("update_stage", stopped_position))
+```
+
+- [ ] **Step 7: Run focused and existing resolution tests**
+
+Run:
+
+```bash
+PYTHONPATH=src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' -q \
+  test/model/test_resolution_change.py \
+  test/model/test_model.py::test_change_resolution \
+  test/model/concurrency/test_concurrency_tools.py::test_incorrect_thread_management
+```
+
+Expected: all pass and no worker remains alive after test cleanup.
+
+- [ ] **Step 8: Commit the model lifecycle**
+
+```bash
+git add src/navigate/model/model.py src/navigate/model/resolution_change.py \
+  test/model/test_resolution_change.py
+git commit -m "fix: cancel active resolution changes before stopping stages" -m \
+  "Reuse analysis: kept Model.change_resolution and Model.stop_stage as canonical entry points and used the existing model event queue. The private task record coordinates their lifecycle without adding a parallel public executor or stop API."
+```
+
+### Task 4: Feature-driven cancellation and safe acquisition termination
+
+**Files:**
+- Create: `test/model/features/test_update_setting.py`
+- Modify: `src/navigate/model/features/update_setting.py`
+- Modify: `test/model/test_model.py`
+- Modify: `docs/source/05_reference/_autosummary/navigate.model.model.Model.rst`
+
+**Interfaces:**
+- Consumes: Task 3 `_begin_resolution_change`, `_perform_resolution_change`, and `_finish_resolution_change` lifecycle.
+- Produces: `ChangeResolution.signal_func() -> bool` returns `False` after cancellation and never prepares/resumes the acquisition path; successful behavior remains unchanged.
+
+- [ ] **Step 1: Write a failing feature cancellation test**
+
+```python
+def test_change_resolution_feature_does_not_prepare_after_cancellation():
+    model = make_feature_model(
+        microscopes={
+            "low": {"1x": (2048, 2048)},
+            "high": {"1x": (2048, 2048)},
+        },
+        active_microscope="low",
+    )
+    feature = ChangeResolution(model, "high", "1x")
+    model._perform_resolution_change.return_value = False
+
+    assert feature.signal_func() is False
+    model.active_microscope.prepare_acquisition.assert_not_called()
+    assert model.stop_acquisition is True
+```
+
+- [ ] **Step 2: Run the feature test and verify RED**
+
+Run:
+
+```bash
+PYTHONPATH=src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' -q \
+  test/model/features/test_update_setting.py
+```
+
+Expected: current feature ignores the resolution result and prepares the new acquisition.
+
+- [ ] **Step 3: Keep the whole feature operation inside the task lifecycle**
+
+Begin the task before pausing data or changing configuration. Use `try/finally` to finish it. If cancelled, set acquisition stop flags, release the paused data thread so it can terminate, skip microscope preparation, waveform event, next-channel preparation, and normal resume, then return `False`.
+
+```python
+task = self.model._begin_resolution_change(self.resolution_mode)
+if task is None:
+    return False
+succeeded = False
+try:
+    self.model.pause_data_thread()
+    if not self.model._perform_resolution_change(task):
+        self.model.stop_acquisition = True
+        self.model.stop_send_signal = True
+        self.model.resume_data_thread()
+        return False
+    waveform_dict = self.model.active_microscope.prepare_acquisition()
+    self.model.event_queue.put(("waveform", waveform_dict))
+    self.model.active_microscope.prepare_next_channel()
+    self.model.resume_data_thread()
+    succeeded = True
+    return True
+finally:
+    self.model._finish_resolution_change(task, succeeded)
+```
+
+- [ ] **Step 4: Synchronize API documentation and run focused tests**
+
+Document the Boolean result and cancellation side effects for `Model.change_resolution` and the keyword-only cancellation behavior of `Model.stop_stage`. Keep the autosummary reference to the existing symbols; do not add the private task class. Run Task 3 tests plus the feature test and existing feature-container tests touching `ChangeResolution`.
+
+- [ ] **Step 5: Commit the feature integration**
+
+```bash
+git add src/navigate/model/features/update_setting.py \
+  test/model/features/test_update_setting.py test/model/test_model.py \
+  docs/source/05_reference/_autosummary/navigate.model.model.Model.rst
+git commit -m "fix: terminate cancelled resolution features safely" -m \
+  "Reuse analysis: ChangeResolution now participates in the model-owned resolution lifecycle. No feature-specific stop path or duplicate acquisition cleanup API was added."
+```
+
+### Task 5: Verify and publish the core safety PR
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md` (checkbox status only)
+
+**Interfaces:**
+- Consumes: Tasks 1-4.
+- Produces: a mergeable core branch that independently prevents collision-causing continuation.
+
+- [ ] **Step 1: Run core formatting and lint**
+
+```bash
+ruff check src/navigate/model/model.py src/navigate/model/microscope.py \
+  src/navigate/model/resolution_change.py \
+  src/navigate/model/features/update_setting.py \
+  src/navigate/controller/controller.py \
+  src/navigate/controller/sub_controllers/stages.py \
+  test/model/test_resolution_change.py \
+  test/model/features/test_update_setting.py \
+  test/controller/test_controller.py \
+  test/controller/sub_controllers/test_stages.py
+black --check src/navigate/model/model.py src/navigate/model/microscope.py \
+  src/navigate/model/resolution_change.py \
+  src/navigate/model/features/update_setting.py \
+  src/navigate/controller/controller.py \
+  src/navigate/controller/sub_controllers/stages.py \
+  test/model/test_resolution_change.py \
+  test/model/features/test_update_setting.py \
+  test/controller/test_controller.py \
+  test/controller/sub_controllers/test_stages.py
+```
+
+- [ ] **Step 2: Run the relevant broader test set**
+
+```bash
+PYTHONPATH=src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' -q \
+  test/model/test_resolution_change.py \
+  test/model/features/test_update_setting.py \
+  test/model/test_model.py \
+  test/controller/test_controller.py
+```
+
+Do not run the Tk-backed `stage_controller` package fixture locally; its direct-handler test has no fixture dependency.
+
+- [ ] **Step 3: Inspect the core diff and commit plan progress**
+
+```bash
+git diff origin/develop --check
+git diff origin/develop --stat
+git log --oneline origin/develop..HEAD
+```
+
+Verify comments are brief and limited to the four non-obvious constraints in Global Constraints. Commit checkbox progress with `docs: record issue 486 core implementation`.
+
+- [ ] **Step 4: Push and open the core PR**
+
+Push `kdean/issue-486-stop-resolution-change` and open a draft PR targeting `develop`. The body links the design and plan, summarizes focused and broader test evidence, records Xvfb/Aqua limitations, requests the designated reviewer if discoverable, and includes `Closes #486`.
+
+### Task 6: Preserve a recovery snapshot and run cancellable return movement
+
+**Files:**
+- Modify: `test/model/test_resolution_change.py`
+- Modify: `src/navigate/model/resolution_change.py`
+- Modify: `src/navigate/model/model.py`
+
+**Interfaces:**
+- Consumes: core terminal `resolution_change_cancelled` event and Task 2 cancellation-aware `move_stage`.
+- Produces: `Model.run_command("resolution_recovery", task_id, choice)` accepting literal choices `"keep"` and `"return"`; terminal `resolution_return_complete` event.
+
+- [ ] **Step 1: Write failing recovery tests**
+
+```python
+def test_keep_resolution_position_discards_snapshot_without_motion():
+    model, recovery = make_cancelled_resolution_model(previous={"x_abs": 4.0})
+    model.run_command("resolution_recovery", recovery.task_id, "keep")
+    assert model.active_microscope.move_stage_calls == []
+    assert model._resolution_recovery is None
+
+
+def test_return_moves_to_literal_snapshot_and_can_be_cancelled():
+    model, recovery = make_cancelled_resolution_model(
+        previous={"x_abs": 4.0, "z_abs": -2.0}
+    )
+    model.run_command("resolution_recovery", recovery.task_id, "return")
+    assert model.return_move_started.wait(1.0)
+    worker = model._resolution_change_task.worker
+    model.stop_stage()
+    worker.join(1.0)
+    assert model.return_move_arguments == {"x_abs": 4.0, "z_abs": -2.0}
+    assert model.return_stage.stop_called.is_set()
+```
+
+- [ ] **Step 2: Run recovery tests and verify RED**
+
+Run the two named tests. Expected: the recovery command and snapshot store are absent.
+
+- [ ] **Step 3: Add recovery ownership and validation**
+
+On terminal cancellation, retain an immutable copy of the pre-movement coordinates in a separate private recovery record after clearing the active task. Mark Return eligible only when every requested axis passes the affected stage's existing strict absolute-position validation. A newer resolution task invalidates an older recovery record.
+
+```python
+@dataclass(frozen=True)
+class _ResolutionRecovery:
+    task_id: int
+    microscope_name: str
+    previous_position: dict[str, float]
+    return_allowed: bool
+```
+
+- [ ] **Step 4: Implement keep and return commands**
+
+Keep atomically clears the matching snapshot and emits no movement. Return validates task ID and eligibility, creates a `returning` task before starting its worker, clears the popup snapshot exactly once, calls the existing cancellation-aware `Model.move_stage(..., wait_until_done=True)`, updates actual positions, and emits `resolution_return_complete` with success or cancellation.
+
+```python
+elif command == "resolution_recovery":
+    task_id, choice = args
+    if choice == "keep":
+        self._keep_resolution_position(task_id)
+    elif choice == "return":
+        self._start_resolution_return(task_id)
+    else:
+        self.event_queue.put(("warning", f"Unknown resolution recovery: {choice}"))
+```
+
+- [ ] **Step 5: Run all model recovery and core tests**
+
+Run `test/model/test_resolution_change.py`, the existing `test_change_resolution`, and the concurrency guard. Expected: pass.
+
+- [ ] **Step 6: Commit recovery movement**
+
+Create branch `kdean/issue-486-resolution-recovery` from the core branch before this commit, then:
+
+```bash
+git add src/navigate/model/model.py src/navigate/model/resolution_change.py \
+  test/model/test_resolution_change.py
+git commit -m "feat: add cancellable resolution position recovery" -m \
+  "Reuse analysis: return movement uses Model.move_stage and the existing Stop Stage lifecycle. No recovery-specific stage executor, limit validator, or stop API was added."
+```
+
+### Task 7: Add the two-choice recovery dialog
+
+**Files:**
+- Create: `src/navigate/view/popups/resolution_change_popup.py`
+- Create: `test/view/popups/test_resolution_change_popup.py`
+- Modify: `src/navigate/controller/controller.py`
+- Modify: `test/controller/test_controller.py`
+
+**Interfaces:**
+- Consumes: `resolution_change_cancelled` and `resolution_return_complete` events; Task 6 recovery command.
+- Produces: `ResolutionChangeCancelledPopup(root, keep_command, return_command, return_enabled)`; controller handlers `_show_resolution_change_cancelled(payload)` and `_finish_resolution_return(payload)`.
+
+- [ ] **Step 1: Write failing popup callback tests without Tk construction**
+
+```python
+def test_popup_close_keeps_current_position():
+    popup = ResolutionChangeCancelledPopup.__new__(ResolutionChangeCancelledPopup)
+    popup.popup = MagicMock()
+    popup._keep_command = MagicMock()
+    popup._keep()
+    popup.popup.dismiss.assert_called_once_with()
+    popup._keep_command.assert_called_once_with()
+
+
+def test_popup_return_dismisses_before_starting_motion():
+    order = []
+    popup = ResolutionChangeCancelledPopup.__new__(ResolutionChangeCancelledPopup)
+    popup.popup = MagicMock(dismiss=lambda: order.append("dismiss"))
+    popup._return_command = lambda: order.append("return")
+    popup._return()
+    assert order == ["dismiss", "return"]
+```
+
+- [ ] **Step 2: Write failing controller event tests**
+
+Patch the popup class with a complete fake exposing `showup`/`dismiss`. Assert that two events with the same task ID create one popup; Keep dispatches `("resolution_recovery", task_id, "keep")`; Return dispatches `"return"`; and `resolution_return_complete` clears the tracked popup/task state.
+
+- [ ] **Step 3: Run popup/controller tests and verify RED**
+
+Run only the new popup tests and named controller tests. Expected: imports and event handlers are absent.
+
+- [ ] **Step 4: Implement the view**
+
+Build a `PopUp` titled `Resolution Change Cancelled` with the approved explanatory text and buttons `Keep Current Position` and `Return to Previous Position`. Focus Keep, bind Escape and `WM_DELETE_WINDOW` to `_keep`, disable Return when `return_enabled` is false, and dismiss before either callback. Do not start model work from the view itself.
+
+```python
+def _keep(self, *_args) -> None:
+    self.popup.dismiss()
+    self._keep_command()
+
+
+def _return(self) -> None:
+    self.popup.dismiss()
+    self._return_command()
+```
+
+- [ ] **Step 5: Implement controller event handling**
+
+Register the two event handlers through the existing event-listener dictionary. Track the displayed task ID to deduplicate and dispatch choices through the existing model thread pool. Before Return, call `stage_controller.view.toggle_button_states(True, stage_controller.stage_axes)` after the modal closes; the separate Stop Stage frame remains enabled. On `resolution_return_complete`, call `stage_controller.force_enable_all_axes()` and clear the tracked task ID.
+
+```python
+def _return_resolution_position(self, task_id: int) -> None:
+    self.stage_controller.view.toggle_button_states(
+        True, self.stage_controller.stage_axes
+    )
+    self.threads_pool.createThread(
+        resourceName="model",
+        target=lambda: self.model.run_command(
+            "resolution_recovery", task_id, "return"
+        ),
+    )
+```
+
+- [ ] **Step 6: Run popup/controller tests and verify GREEN**
+
+Run the Step 3 tests. Expected: pass without creating `tk.Tk()` locally.
+
+- [ ] **Step 7: Commit the recovery UI**
+
+```bash
+git add src/navigate/view/popups/resolution_change_popup.py \
+  src/navigate/controller/controller.py \
+  test/view/popups/test_resolution_change_popup.py \
+  test/controller/test_controller.py
+git commit -m "feat: offer safe resolution-change recovery choices"
+```
+
+### Task 8: Verify and publish the stacked recovery PR
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md` (checkbox status only)
+
+**Interfaces:**
+- Consumes: Tasks 6-7 and the core PR branch.
+- Produces: a focused stacked recovery PR whose base is the core branch until the core merges.
+
+- [ ] **Step 1: Run formatting, lint, and focused tests**
+
+Run Ruff and Black on all recovery-modified files. Run the full model resolution test file, feature test, controller tests, and popup callback tests.
+
+- [ ] **Step 2: Run a native GUI smoke check outside Aqua**
+
+Use Windows CI or a Linux X11 Tk environment:
+
+```bash
+xvfb-run -a /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' -q \
+  test/view/popups/test_resolution_change_popup.py
+```
+
+If the available environment is macOS Aqua Tk, skip window construction and explicitly report that Xvfb cannot isolate it.
+
+- [ ] **Step 3: Review the stacked diff**
+
+```bash
+git diff kdean/issue-486-stop-resolution-change --check
+git diff kdean/issue-486-stop-resolution-change --stat
+git log --oneline kdean/issue-486-stop-resolution-change..HEAD
+```
+
+Confirm that the recovery PR contains no duplicate stage executor, stop path, or acquisition restart.
+
+- [ ] **Step 4: Push and open the recovery PR**
+
+Push `kdean/issue-486-resolution-recovery` and open a draft PR based on `kdean/issue-486-stop-resolution-change`. Link the design, plan, and core PR; list test evidence and Xvfb limitation; request the designated reviewer if known; and reference #486 without a second closing directive.

--- a/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md
+++ b/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md
@@ -713,3 +713,57 @@ Confirm that the recovery PR contains no duplicate stage executor, stop path, or
 - [ ] **Step 4: Push and open the recovery PR**
 
 Push `kdean/issue-486-resolution-recovery` and open a draft PR based on `kdean/issue-486-stop-resolution-change`. Link the design, plan, and core PR; list test evidence and Xvfb limitation; request the designated reviewer if known; and reference #486 without a second closing directive.
+
+### Task 9: Cover both Stop Stage GUI bindings headlessly
+
+**Files:**
+- Create: `test/controller/test_stop_stage_button_bindings.py`
+- Modify: `docs/superpowers/specs/2026-08-04-issue-486-resolution-change-cancellation-design.md`
+- Modify: `docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md`
+
+**Interfaces:**
+- Consumes: `StageController.__init__`, `StageController.stop_button_handler`, and `Controller.update_acquire_control`.
+- Produces: regression coverage proving each visible Stop Stage button independently dispatches the literal `"stop_stage"` command.
+
+- [x] **Step 1: Add a headless button double and controller fixture**
+
+Create a test-only `_InvokableButton` whose `configure`/`config` methods retain
+the command and whose `invoke()` method executes it. Construct the real
+`StageController` with no configured axes and suppress only unrelated
+initialization callbacks; do not construct `tk.Tk()` or production widgets.
+
+- [x] **Step 2: Add independent click tests**
+
+```python
+def test_stage_control_stop_button_click_dispatches_stop_stage():
+    _, stage_button, _, executed_commands = _build_headless_controller()
+    stage_button.invoke()
+    assert executed_commands == ["stop_stage"]
+
+
+def test_acquisition_bar_stop_button_click_dispatches_stop_stage():
+    _, _, acquisition_button, executed_commands = _build_headless_controller()
+    acquisition_button.invoke()
+    assert executed_commands == ["stop_stage"]
+```
+
+- [x] **Step 3: Verify binding-specific RED states**
+
+Temporarily remove the Stage Control binding and run its named test; expect a
+failure because the button has no command. Restore it, temporarily remove the
+acquisition-bar binding, and run its named test; expect the corresponding
+failure. Restore both production files exactly.
+
+- [x] **Step 4: Verify GREEN and surrounding safety coverage**
+
+Run the two new tests, the existing direct-handler test, controller Stop Stage
+tests, and the resolution-change safety tests with the repository's configured
+Navigate Python. Run Ruff, Black check, and `git diff --check` on the final
+changes.
+
+- [x] **Step 5: Commit and update PR #1236**
+
+Commit only the new test and the design/plan updates, then push the commit as a
+fast-forward update to `kdean/issue-486-stop-resolution-change`. Confirm the
+live PR head and report fresh CI status without treating absent or pending jobs
+as success.

--- a/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md
+++ b/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md
@@ -216,7 +216,7 @@ git commit -m "fix: make resolution stage moves cancellable" -m \
 - Consumes: Task 2 cancellation-aware movement and best-effort stop methods.
 - Produces: private `_ResolutionChangeTask`; `Model._begin_resolution_change(resolution_value)`, `_perform_resolution_change(task)`, `_finish_resolution_change(task, succeeded)`, `_start_resolution_setting_update()`, cancellation-aware `Model.stop_stage(cancel_resolution_change=True)`, and `Model.move_stage(..., cancel_event=None) -> bool`; `Model.change_resolution(resolution_value) -> bool` remains the synchronous public entry point.
 
-- [ ] **Step 1: Write failing task and stop-order tests**
+- [x] **Step 1: Write failing task and stop-order tests**
 
 ```python
 def test_stop_stage_records_cancellation_before_hardware_stop():
@@ -256,7 +256,7 @@ def test_terminate_cancels_and_joins_resolution_worker():
     assert worker.is_alive() is False
 ```
 
-- [ ] **Step 2: Run the task tests and verify RED**
+- [x] **Step 2: Run the task tests and verify RED**
 
 Run:
 
@@ -268,7 +268,7 @@ PYTHONPATH=src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' -
 
 Expected: the private lifecycle is absent and current Stop Stage cannot cancel the worker.
 
-- [ ] **Step 3: Add the private task record and model initialization**
+- [x] **Step 3: Add the private task record and model initialization**
 
 ```python
 @dataclass
@@ -287,7 +287,7 @@ class _ResolutionChangeTask:
 
 Initialize a lock, counter, and optional current task in `Model.__init__`. `_begin_resolution_change` rejects an existing active task with a model warning event.
 
-- [ ] **Step 4: Refactor successful resolution movement behind the task**
+- [x] **Step 4: Refactor successful resolution movement behind the task**
 
 Move the physical body of `change_resolution` into `_perform_resolution_change(task)`. Capture the target stage position immediately before the first resolution-induced stage move, pass `task.cancel_event` through Task 2 methods, and check cancellation before zoom, offset, final stage update, waveform work, and acquisition restart. Extend `Model.move_stage` with an optional `cancel_event` that forwards to `Microscope.move_stage`. The public `change_resolution` creates and finishes a synchronous task and returns success.
 
@@ -311,7 +311,7 @@ def _perform_resolution_change(self, task: _ResolutionChangeTask) -> bool:
     # Existing zoom-offset logic continues here and passes task.cancel_event.
 ```
 
-- [ ] **Step 5: Make manual setting updates model-owned and asynchronous**
+- [x] **Step 5: Make manual setting updates model-owned and asynchronous**
 
 Extract the existing `run_command("update_setting")` body to `_update_setting(command, resolution_task=None)`. For `"resolution"`, create the task before starting a `ThreadWithWarning` worker and return immediately. For other settings such as `"galvo"`, retain synchronous behavior. On cancellation set acquisition stop flags, release a paused data thread, avoid waveform publication/restart, and complete the task as cancelled.
 
@@ -323,7 +323,7 @@ elif command == "update_setting":
     self._update_setting(args[0])
 ```
 
-- [ ] **Step 6: Implement ordered best-effort Stop Stage**
+- [x] **Step 6: Implement ordered best-effort Stop Stage**
 
 Set the active task's cancellation event and state under its lock before calling any device. Stop former, target, and active microscopes with one shared set of attempted stage IDs. Record errors, read the actual active position, update configuration, and publish `update_stage`. Do not wait for the worker before issuing stops. The worker publishes `resolution_change_cancelled` only after reaching terminal state. Extend `Model.terminate` to set cancellation, issue the same stage stop, and join the active worker before microscope teardown.
 
@@ -346,7 +346,7 @@ def stop_stage(self, *, cancel_resolution_change: bool = True) -> None:
     self.event_queue.put(("update_stage", stopped_position))
 ```
 
-- [ ] **Step 7: Run focused and existing resolution tests**
+- [x] **Step 7: Run focused and existing resolution tests**
 
 Run:
 
@@ -359,7 +359,7 @@ PYTHONPATH=src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' -
 
 Expected: all pass and no worker remains alive after test cleanup.
 
-- [ ] **Step 8: Commit the model lifecycle**
+- [x] **Step 8: Commit the model lifecycle**
 
 ```bash
 git add src/navigate/model/model.py src/navigate/model/resolution_change.py \
@@ -380,7 +380,7 @@ git commit -m "fix: cancel active resolution changes before stopping stages" -m 
 - Consumes: Task 3 `_begin_resolution_change`, `_perform_resolution_change`, and `_finish_resolution_change` lifecycle.
 - Produces: `ChangeResolution.signal_func() -> bool` returns `False` after cancellation and never prepares/resumes the acquisition path; successful behavior remains unchanged.
 
-- [ ] **Step 1: Write a failing feature cancellation test**
+- [x] **Step 1: Write a failing feature cancellation test**
 
 ```python
 def test_change_resolution_feature_does_not_prepare_after_cancellation():
@@ -399,7 +399,7 @@ def test_change_resolution_feature_does_not_prepare_after_cancellation():
     assert model.stop_acquisition is True
 ```
 
-- [ ] **Step 2: Run the feature test and verify RED**
+- [x] **Step 2: Run the feature test and verify RED**
 
 Run:
 
@@ -410,7 +410,7 @@ PYTHONPATH=src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' -
 
 Expected: current feature ignores the resolution result and prepares the new acquisition.
 
-- [ ] **Step 3: Keep the whole feature operation inside the task lifecycle**
+- [x] **Step 3: Keep the whole feature operation inside the task lifecycle**
 
 Begin the task before pausing data or changing configuration. Use `try/finally` to finish it. If cancelled, set acquisition stop flags, release the paused data thread so it can terminate, skip microscope preparation, waveform event, next-channel preparation, and normal resume, then return `False`.
 
@@ -436,11 +436,11 @@ finally:
     self.model._finish_resolution_change(task, succeeded)
 ```
 
-- [ ] **Step 4: Synchronize API documentation and run focused tests**
+- [x] **Step 4: Synchronize API documentation and run focused tests**
 
 Document the Boolean result and cancellation side effects for `Model.change_resolution` and the keyword-only cancellation behavior of `Model.stop_stage`. Keep the autosummary reference to the existing symbols; do not add the private task class. Run Task 3 tests plus the feature test and existing feature-container tests touching `ChangeResolution`.
 
-- [ ] **Step 5: Commit the feature integration**
+- [x] **Step 5: Commit the feature integration**
 
 ```bash
 git add src/navigate/model/features/update_setting.py \

--- a/docs/superpowers/specs/2026-08-04-issue-486-resolution-change-cancellation-design.md
+++ b/docs/superpowers/specs/2026-08-04-issue-486-resolution-change-cancellation-design.md
@@ -1,0 +1,246 @@
+# Issue 486 Resolution-Change Cancellation Design
+
+## Summary
+
+Issue #486 remains present on `origin/develop`: changing resolution starts a
+blocking model operation, and the controller joins the worker from the Tk event
+loop. While a stage is executing the resolution offset, Stop Stage cannot
+reliably reach the model or the stage driver. This is a physical-safety concern
+because continued motion could cause a collision.
+
+Stop Stage must cancel the active resolution-change task, immediately attempt
+to stop every stage device participating in that transition, and prevent the
+worker from scheduling any later motion. After the worker acknowledges
+cancellation and Navigate reads the stopped positions, the user may either keep
+the stages where they stopped or explicitly return them to their pre-movement
+positions.
+
+## Safety Contract
+
+The implementation must preserve this ordering:
+
+1. Record cancellation before issuing any hardware command so the resolution
+   worker cannot begin another stage move.
+2. Attempt `stop()` on every unique stage device participating in the
+   transition. An exception from one device must not prevent stopping the
+   remaining devices.
+3. Require the resolution worker to check cancellation before and after each
+   blocking movement and before any later configuration or acquisition work.
+4. Wait for worker acknowledgement before enabling recovery movement.
+5. Read the actual stopped positions and update the GUI.
+6. Start return movement only after an explicit user selection.
+
+"Immediately" means that the Stop Stage event has no Tk `after()` debounce,
+controller-side worker join, or intentional delay before the hardware stop is
+dispatched. Physical stopping latency remains controlled by the hardware and
+its driver.
+
+If stop or position readback fails, Navigate must preserve the safest known
+state, report the error, and withhold Return to Previous Position. It must never
+guess a recovery coordinate.
+
+## Architecture
+
+### Model-owned resolution task
+
+The model process will own a private resolution-task coordinator protected by a
+lock. At most one resolution change or recovery return may be active. Its task
+record contains:
+
+- a monotonically unique task ID;
+- a cancellation event;
+- the lifecycle state (`changing`, `cancel_requested`, `cancelled`,
+  `returning`, or `completed`);
+- former and target microscope and zoom values;
+- the affected microscope and unique stage devices;
+- stopped positions and, when recovery support is present, pre-movement
+  positions;
+- the worker thread and any terminal error.
+
+Manual resolution changes will ask the model to start the worker and then
+return, leaving the ObjectInSubprocess command channel available for Stop Stage.
+Feature-driven `ChangeResolution` operations will register their existing
+signal thread with the same coordinator and obey the same cancellation checks.
+
+A concurrent resolution request will be rejected with a warning. It will not
+be queued behind a moving stage, because an out-of-date queued resolution can
+produce unexpected motion after the current task ends.
+
+### Cooperative movement cancellation
+
+The current `Model.change_resolution`, `Microscope.move_stage_offset`, and
+`Microscope.move_stage` paths will be extended with optional cooperative
+cancellation. Movement code checks the cancellation event immediately before
+and after every blocking device call. A cancellation after one device stops the
+loop before another device can begin moving.
+
+The model's Stop Stage entry point will set the task cancellation event before
+calling hardware `stop()`. Calls made internally only to refresh stage state at
+the successful end of a resolution change must not cancel their own task.
+
+The controller will remove the 250-ms Stage Stop debounce and will not join the
+resolution worker from the Tk thread. Its safety-stop worker will retry the
+transient ObjectInSubprocess concurrency error currently handled for acquisition
+stopping, while logging why the retry is necessary. It will not silently lose a
+stop request in `ThreadPool` exception handling.
+
+### Cancellation completion event
+
+After all stop attempts, the resolution worker must reach a terminal cancelled
+state before the model emits the cancellation-complete event. The core
+serializable event payload contains the task ID, actual microscope and zoom,
+stopped position, and any stop/readback error. The recovery PR enriches that
+payload with the pre-movement position and Return eligibility.
+
+The controller's existing model event queue remains the only child-to-GUI event
+route. The Tk event pump creates or updates the recovery dialog on the Tk thread.
+Duplicate task events cannot create duplicate dialogs or return movements.
+
+### Recovery semantics
+
+"Previous position" means the coordinates read from each affected physical
+stage immediately before the first stage movement caused by the resolution
+change. For a cross-microscope transition, Navigate selects the target stage
+hardware and records its position before applying the configured microscope
+offset. Shared stage devices are deduplicated.
+
+Return to Previous Position:
+
+- moves the affected stages to those exact saved coordinates;
+- leaves the currently active microscope and resolution selected;
+- preserves the configured stage-limit policy and never disables limits;
+- begins only after the cancelled worker is quiescent;
+- runs as a new model-owned worker so the command channel stays available;
+- can itself be cancelled with Stop Stage; and
+- leaves the stages at their newest stopped positions after failure or a second
+  cancellation.
+
+If positions are missing, invalid, or cannot be associated with the affected
+stage devices, Return is unavailable.
+
+### Recovery dialog
+
+The dialog title is **Resolution Change Cancelled**. Its body explains that the
+stages are stopped at the positions shown in Navigate and that returning will
+move them again. It presents two explicit choices:
+
+- **Keep Current Position** (safe default)
+- **Return to Previous Position**
+
+Closing the window or pressing Escape is identical to Keep Current Position.
+The dialog closes before a return worker starts, ensuring the normal Stop Stage
+control is available during return. Other stage and resolution controls remain
+disabled while return motion is active; Stop Stage remains enabled.
+
+### Acquisition state
+
+Cancellation must not resume live or customized acquisition. It must not
+calculate or publish new waveforms, prepare the next feature, or restart a signal
+thread after an interrupted resolution change. The GUI is reconciled to the
+microscope, zoom, and stage positions reported by the model. The user explicitly
+restarts acquisition after choosing Keep or Return.
+
+Application termination cancels any outstanding resolution or recovery worker,
+issues the normal stage stop, and joins the worker before device teardown.
+
+## Reuse Analysis
+
+The closest existing lifecycle and transport mechanisms are:
+
+- `Controller.execute("resolution")` and
+  `Model.run_command("update_setting", "resolution")` for resolution requests;
+- `Model.change_resolution` for microscope and zoom transitions;
+- `Microscope.move_stage_offset` and `Microscope.move_stage` for physical
+  movement;
+- `Controller.execute("stop_stage")`, `Controller.stop_stage`,
+  `Model.stop_stage`, and `Microscope.stop_stage` for stage stopping;
+- `Controller.sloppy_stop` for retrying a safety command rejected by
+  ObjectInSubprocess concurrency protection;
+- the model event queue and controller event listeners for child-to-GUI state;
+  and
+- `PopUp` for transient modal dialogs.
+
+The implementation extends these symbols rather than adding a second stage
+executor, stop lifecycle, event transport, or public cancellation wrapper. Any
+changed user-callable signatures will receive complete Numpydoc documentation,
+including cancellation behavior, return meaning, side effects, and error
+semantics. Reference documentation and tests will be updated with the code.
+
+Brief comments will explain only the non-obvious safety constraints: why the
+cancel flag precedes hardware stop, why cancellation is checked on both sides of
+a blocking driver call, why the controller retries proxy contention, and why a
+return cannot start before worker acknowledgement.
+
+## Testing Strategy
+
+Tests will be written before production changes and observed failing for the
+expected missing behavior. A blocking stage double will model a real
+`move_absolute(..., wait_until_done=True)` operation that releases only after
+`stop()`.
+
+Core tests cover:
+
+- the Stop Stage handler dispatching without a 250-ms Tk delay;
+- the manual resolution command returning while movement remains active;
+- cancellation being recorded before the first hardware stop call;
+- all participating stage devices receiving a stop attempt despite one failure;
+- no subsequent stage, zoom-offset, waveform, or acquisition work after
+  cancellation;
+- cancellation between distinct stage-device moves;
+- same-microscope zoom and cross-microscope offset transitions;
+- feature-driven resolution changes terminating their feature/acquisition path;
+- model-proxy contention retrying instead of dropping Stop Stage;
+- stopped-position readback and event payload correctness; and
+- termination cancelling and joining outstanding workers.
+
+Recovery tests cover:
+
+- dialog creation on the Tk thread and deduplication by task ID;
+- Close, Escape, and Keep causing no movement;
+- Return using literal saved coordinates exactly once;
+- invalid or missing snapshots disabling Return;
+- configured stage limits remaining enabled;
+- return movement remaining cancellable; and
+- acquisition staying stopped after either recovery choice.
+
+Focused model and controller tests run locally without launching Aqua Tk. GUI
+widget tests run under native Windows CI and, if a Linux Tk test lane is added,
+under `xvfb-run -a`. The Homebrew Xvfb server cannot isolate this environment's
+Aqua/AppKit Tk build because it is not an X11 client.
+
+## Rollout and Review Boundaries
+
+The work will be prepared as two stacked, independently reviewable pull
+requests unless implementation reveals an unsafe boundary:
+
+1. **Core cancellation and hardware stop.** Removes GUI blocking, adds the
+   model-owned resolution lifecycle, cooperatively cancels movement, strengthens
+   Stop Stage delivery, prevents acquisition restart, and supplies focused
+   safety tests. This PR independently resolves the collision hazard.
+2. **Recovery dialog and cancellable return.** Builds on the terminal
+   cancellation event, adds the two-choice popup, position snapshots, validated
+   return movement, GUI state management, and focused UI/recovery tests.
+
+The first PR must be safe and useful without the second. If the recovery work
+requires changing the first PR's core lifecycle contract, the branches will be
+recombined into one PR rather than exposing an unstable stacked interface.
+
+Each PR will use a detailed description, request the repository's designated
+reviewer when known, and link its plan and reuse analysis. The core PR will use
+`Closes #486`; the stacked recovery PR will reference the core PR without a
+second closing directive.
+
+## Acceptance Criteria
+
+- Stop Stage remains clickable during every resolution-change stage movement.
+- Its handler dispatches without a Tk debounce or controller-side join.
+- The cancellation flag is set before stage stop commands are attempted.
+- Every participating stage device receives a stop attempt.
+- No resolution or acquisition operation schedules new motion after
+  cancellation.
+- The GUI shows the actual stopped stage coordinates.
+- Recovery movement never starts without explicit Return selection.
+- Close, Escape, and Keep leave the stages stopped where they are.
+- Return uses the recorded pre-movement coordinates and can be stopped again.
+- Live and customized acquisitions remain stopped after cancellation.
+- Focused tests, formatting, lint, and relevant broader tests pass.

--- a/docs/superpowers/specs/2026-08-04-issue-486-resolution-change-cancellation-design.md
+++ b/docs/superpowers/specs/2026-08-04-issue-486-resolution-change-cancellation-design.md
@@ -208,6 +208,21 @@ widget tests run under native Windows CI and, if a Linux Tk test lane is added,
 under `xvfb-run -a`. The Homebrew Xvfb server cannot isolate this environment's
 Aqua/AppKit Tk build because it is not an X11 client.
 
+### Headless coverage for both Stop Stage buttons
+
+The Stage Control tab and acquisition bar expose separate Stop Stage buttons,
+but both must invoke the same immediate `StageController.stop_button_handler`
+path. Two independent regression tests will construct the real controller
+bindings around lightweight button doubles that store a configured command and
+execute it through `invoke()`. One test clicks the Stage Control tab button and
+the other clicks the acquisition bar button; each asserts the resulting
+`"stop_stage"` command recorded at the parent-controller boundary.
+
+These tests will not construct Tk widgets or open windows. Their mutation check
+is binding-specific: deleting either production binding must fail its own test
+without relying on the direct handler unit test. No production refactor or new
+public API is required for this coverage.
+
 ## Rollout and Review Boundaries
 
 The work will be prepared as two stacked, independently reviewable pull

--- a/src/navigate/controller/controller.py
+++ b/src/navigate/controller/controller.py
@@ -1846,7 +1846,9 @@ class Controller:
             try:
                 self.model.stop_stage()
                 return
-            except RuntimeError:
+            except RuntimeError as e:
+                if "ObjectInSubprocess at the same time" not in str(e):
+                    raise
                 # ObjectInSubprocess rejects concurrent proxy calls. A safety stop
                 # must be retried instead of disappearing in the thread pool.
                 time.sleep(0.001)

--- a/src/navigate/controller/controller.py
+++ b/src/navigate/controller/controller.py
@@ -1226,11 +1226,10 @@ class Controller:
                 return
 
             self.change_microscope(temp[0], temp[1])
-            work_thread = self.threads_pool.createThread(
+            self.threads_pool.createThread(
                 resourceName="model",
                 target=lambda: self.model.run_command("update_setting", "resolution"),
             )
-            work_thread.join()
 
         elif command == "set_save":
             """Set whether the image will be saved.
@@ -1843,7 +1842,14 @@ class Controller:
         -------
         None
         """
-        self.model.stop_stage()
+        while True:
+            try:
+                self.model.stop_stage()
+                return
+            except RuntimeError:
+                # ObjectInSubprocess rejects concurrent proxy calls. A safety stop
+                # must be retried instead of disappearing in the thread pool.
+                time.sleep(0.001)
 
     def update_stage_limits(self, microscope_name: str) -> None:
         """Update stage limits on the device side

--- a/src/navigate/controller/sub_controllers/stages.py
+++ b/src/navigate/controller/sub_controllers/stages.py
@@ -504,14 +504,14 @@ class StageController(GUIController):
         return handler
 
     def stop_button_handler(self, *args: Iterable) -> None:
-        """This function stops the stage after a 250 ms debouncing period of time.
+        """Request an immediate stop for all stages.
 
         Parameters
         ----------
         *args : Iterable
             Variable length argument list
         """
-        self.view.after(250, lambda *args: self.parent_controller.execute("stop_stage"))
+        self.parent_controller.execute("stop_stage")
 
     #    Tai's home button
     def home_button_handler(self, *args: Iterable) -> None:

--- a/src/navigate/model/features/update_setting.py
+++ b/src/navigate/model/features/update_setting.py
@@ -144,31 +144,47 @@ class ChangeResolution:
             # logger.exception(error_message) doesn't work
             print(error_message)
             raise Exception(error_message)
-        # pause data thread
-        self.model.pause_data_thread()
-        # end active microscope
-        self.model.active_microscope.end_acquisition()
-        # prepare new microscope
-        self.model.configuration["experiment"]["MicroscopeState"][
-            "microscope_name"
-        ] = self.resolution_mode
-        self.model.configuration["experiment"]["MicroscopeState"][
-            "zoom"
-        ] = self.zoom_value
-        self.model.change_resolution(self.resolution_mode)
-        logger.debug(f"current resolution is {self.resolution_mode}")
-        logger.debug(
-            f"current active microscope is {self.model.active_microscope_name}"
-        )
-        # prepare active microscope
-        waveform_dict = self.model.active_microscope.prepare_acquisition()
-        self.model.event_queue.put(("waveform", waveform_dict))
-        self.model.frame_id = 0
-        # prepare channel
-        self.model.active_microscope.prepare_next_channel()
-        # resume data thread
-        self.model.resume_data_thread()
-        return True
+        task = self.model._begin_resolution_change(self.resolution_mode)
+        if task is None:
+            return False
+
+        succeeded = False
+        data_thread_paused = False
+        try:
+            self.model.pause_data_thread()
+            data_thread_paused = True
+            self.model.active_microscope.end_acquisition()
+            self.model.configuration["experiment"]["MicroscopeState"][
+                "microscope_name"
+            ] = self.resolution_mode
+            self.model.configuration["experiment"]["MicroscopeState"][
+                "zoom"
+            ] = self.zoom_value
+
+            if not self.model._perform_resolution_change(task):
+                self.model.stop_acquisition = True
+                self.model.stop_send_signal = True
+                # Release the data thread so it can observe the stop request.
+                self.model.resume_data_thread()
+                data_thread_paused = False
+                return False
+
+            logger.debug(f"current resolution is {self.resolution_mode}")
+            logger.debug(
+                f"current active microscope is {self.model.active_microscope_name}"
+            )
+            waveform_dict = self.model.active_microscope.prepare_acquisition()
+            self.model.event_queue.put(("waveform", waveform_dict))
+            self.model.frame_id = 0
+            self.model.active_microscope.prepare_next_channel()
+            self.model.resume_data_thread()
+            data_thread_paused = False
+            succeeded = True
+            return True
+        finally:
+            if data_thread_paused:
+                self.model.resume_data_thread()
+            self.model._finish_resolution_change(task, succeeded)
 
     def cleanup(self):
         """Perform cleanup actions if needed.

--- a/src/navigate/model/microscope.py
+++ b/src/navigate/model/microscope.py
@@ -50,6 +50,13 @@ p = __name__.split(".")[1]
 logger = logging.getLogger(p)
 
 
+def _is_movement_cancelled(
+    cancel_event: Optional[threading.Event],
+) -> bool:
+    """Return whether cooperative stage cancellation was requested."""
+    return cancel_event is not None and cancel_event.is_set()
+
+
 class Microscope:
     """Microscope Class - Used to control the microscope."""
 
@@ -392,13 +399,32 @@ class Microscope:
         self.data_buffer = data_buffer
         self.number_of_frames = number_of_frames
 
-    def move_stage_offset(self, former_microscope: Optional[str] = None) -> None:
+    def move_stage_offset(
+        self,
+        former_microscope: Optional[str] = None,
+        cancel_event: Optional[threading.Event] = None,
+    ) -> bool:
         """Move the stage to the offset position.
 
         Parameters
         ----------
         former_microscope : Optional[str], optional
             Name of the former microscope.
+        cancel_event : Optional[threading.Event], optional
+            Cooperative cancellation signal owned by the calling operation. When set,
+            no later stage device is commanded.
+
+        Returns
+        -------
+        bool
+            ``True`` when every requested stage move completes. ``False`` when
+            cancellation is requested or a stage reports failure.
+
+        Notes
+        -----
+        A blocking device call cannot be interrupted by the event alone. Callers must
+        also issue the hardware stage stop, after which this method observes the event
+        before another device can move.
         """
 
         if former_microscope:
@@ -412,7 +438,10 @@ class Microscope:
         ]["stage"]
         self.ask_stage_for_position = True
         pos_dict = self.get_stage_position()
+        success = True
         for stage, axes in self.stages_list:
+            if _is_movement_cancelled(cancel_event):
+                return False
 
             # x_abs: current x_pos + current_x_offset - former_x_offset
             pos = {
@@ -424,8 +453,11 @@ class Microscope:
                 )
                 for axis in axes
             }
-            stage.move_absolute(pos, wait_until_done=True)
+            success = stage.move_absolute(pos, wait_until_done=True) and success
+            if _is_movement_cancelled(cancel_event):
+                return False
         self.ask_stage_for_position = True
+        return success
 
     def prepare_acquisition(self) -> dict:
         """Prepare the acquisition.
@@ -956,7 +988,11 @@ class Microscope:
         logger.info(f"Stage position caching: {self.cache_stage_positions} ")
 
     def move_stage(
-        self, pos_dict: dict, wait_until_done: bool = False, update_focus: bool = True
+        self,
+        pos_dict: dict,
+        wait_until_done: bool = False,
+        update_focus: bool = True,
+        cancel_event: Optional[threading.Event] = None,
     ) -> bool:
         """Move stage to a position.
 
@@ -968,12 +1004,25 @@ class Microscope:
             Wait until stage is done moving, by default False
         update_focus : bool, optional
             Update the central focus
+        cancel_event : Optional[threading.Event], optional
+            Cooperative cancellation signal owned by the calling operation. When set,
+            no later stage device is commanded.
 
         Returns
         -------
         success : bool
-            True if stage is successfully moved, False otherwise.
+            ``True`` if the stage is successfully moved. ``False`` on cancellation or
+            device-reported failure.
+
+        Notes
+        -----
+        A blocking device call cannot be interrupted by the event alone. Callers must
+        also issue the hardware stage stop, after which this method observes the event
+        before another device can move.
         """
+
+        if _is_movement_cancelled(cancel_event):
+            return False
 
         if self.cache_stage_positions:
             # cache stage positions in z-stack and customized modes.
@@ -988,12 +1037,15 @@ class Microscope:
             axis = axis_key[: axis_key.index("_")]
             if update_focus and axis == "f":
                 self._clear_zero_defocus_focus()
-            return self.stages[axis].move_axis_absolute(
+            success = self.stages[axis].move_axis_absolute(
                 axis, pos_dict[axis_key], wait_until_done
             )
+            return success and not _is_movement_cancelled(cancel_event)
 
         success = True
         for stage, axes in self.stages_list:
+            if _is_movement_cancelled(cancel_event):
+                return False
             pos = {
                 axis: pos_dict[axis]
                 for axis in pos_dict
@@ -1001,21 +1053,54 @@ class Microscope:
             }
             if pos:
                 success = stage.move_absolute(pos, wait_until_done) and success
+                if _is_movement_cancelled(cancel_event):
+                    return False
 
         if update_focus and "f_abs" in pos_dict:
             self._clear_zero_defocus_focus()
 
         return success
 
-    def stop_stage(self) -> None:
-        """Stop stage."""
+    def stop_stage(self, stopped_stage_ids: Optional[set[int]] = None) -> List[str]:
+        """Stop every unique stage device on this microscope.
+
+        Parameters
+        ----------
+        stopped_stage_ids : Optional[set[int]], optional
+            Object IDs of stage devices whose stop has already been attempted. The set
+            is updated in place so callers can deduplicate shared devices across
+            microscope configurations.
+
+        Returns
+        -------
+        list[str]
+            Error descriptions from failed stop attempts. All remaining unique stages
+            are attempted after an error.
+
+        Notes
+        -----
+        Device IDs are recorded before calling ``stop`` so a failing shared device is
+        not repeatedly invoked through another axis or microscope configuration.
+        """
 
         self.ask_stage_for_position = True
+        if stopped_stage_ids is None:
+            stopped_stage_ids = set()
+        errors = []
 
         for stage, axes in self.stages_list:
-            stage.stop()
+            stage_id = id(stage)
+            if stage_id in stopped_stage_ids:
+                continue
+            stopped_stage_ids.add(stage_id)
+            try:
+                stage.stop()
+            except Exception as e:
+                logger.exception("Failed to stop stage device")
+                errors.append(f"{type(e).__name__}: {e}")
 
         self.central_focus = self.get_stage_position().get("f_pos", self.central_focus)
+        return errors
 
     def get_stage_position(self) -> dict:
         """Get stage position.

--- a/src/navigate/model/model.py
+++ b/src/navigate/model/model.py
@@ -955,16 +955,34 @@ class Model:
         stopped_stage_ids = set()
         stop_errors = []
         for microscope_name in dict.fromkeys(microscope_names):
-            stop_errors.extend(
-                self.microscopes[microscope_name].stop_stage(stopped_stage_ids)
-            )
+            try:
+                stop_errors.extend(
+                    self.microscopes[microscope_name].stop_stage(stopped_stage_ids)
+                )
+            except Exception as e:
+                self.logger.exception(
+                    "Failed while stopping stages for %s", microscope_name
+                )
+                stop_errors.append(f"{type(e).__name__}: {e}")
 
-        ret_pos_dict = self.get_stage_position()
+        if cancel_resolution_change and task is not None:
+            task.stop_errors.extend(stop_errors)
+
+        try:
+            ret_pos_dict = self.get_stage_position()
+        except Exception as e:
+            self.logger.exception("Failed to read stage position after stopping")
+            error = f"{type(e).__name__}: {e}"
+            if cancel_resolution_change and task is not None:
+                task.stop_errors.append(error)
+            self.event_queue.put(
+                ("warning", f"Stages were stopped, but position readback failed: {e}")
+            )
+            return
         update_stage_dict(self, ret_pos_dict)
         self.event_queue.put(("update_stage", ret_pos_dict))
         if cancel_resolution_change and task is not None:
             task.stopped_position = ret_pos_dict
-            task.stop_errors.extend(stop_errors)
 
     def end_acquisition(self) -> None:
         """End the acquisition.
@@ -1614,10 +1632,7 @@ class Model:
                     succeeded = self.change_resolution(microscope_name) is not False
                 else:
                     succeeded = self._perform_resolution_change(resolution_task)
-                if (
-                    resolution_task is not None
-                    and resolution_task.cancel_event.is_set()
-                ):
+                if not succeeded:
                     self.stop_acquisition = True
                     self.stop_send_signal = True
                     if reboot:

--- a/src/navigate/model/model.py
+++ b/src/navigate/model/model.py
@@ -78,6 +78,7 @@ from navigate.tools.common_dict_tools import update_stage_dict
 from navigate.tools.common_functions import load_module_from_file, VariableWithLock
 from navigate.tools.file_functions import load_yaml_file, save_yaml_file
 from navigate.model.microscope import Microscope
+from navigate.model.resolution_change import _ResolutionChangeTask
 from navigate.config.config import get_navigate_path
 from navigate.model.plugins_model import PluginsModel
 
@@ -246,6 +247,11 @@ class Model:
 
         #: bool: Stop signal thread?
         self.stop_send_signal = False  # stop signal thread
+
+        # Resolution changes outlive the proxy call so Stop Stage can reach the model.
+        self._resolution_change_lock = threading.Lock()
+        self._resolution_change_counter = 0
+        self._resolution_change_task = None
 
         #: bool: Signal side completed a finite acquisition.
         self.signal_acquisition_complete = False
@@ -685,51 +691,10 @@ class Model:
             consisting of the resolution_mode, the zoom, and the laser_info.
             e.g., self.resolution_info['waveform_constants'][self.resolution][self.mag]
             """
-            reboot = False
-            microscope_name = self.configuration["experiment"]["MicroscopeState"][
-                "microscope_name"
-            ]
-            if self.is_acquiring:
-                # We called this while in the middle of an acquisition
-                # stop live thread
-                self.stop_send_signal = True
-                self.signal_thread.join()
-                if microscope_name != self.active_microscope_name:
-                    self.pause_data_thread()
-                    self.active_microscope.end_acquisition()
-                    reboot = True
-                self.active_microscope.current_channel = 0
-
             if args[0] == "resolution":
-                self.change_resolution(
-                    self.configuration["experiment"]["MicroscopeState"][
-                        "microscope_name"
-                    ]
-                )
-
-            if reboot:
-                # prepare active microscope
-                waveform_dict = self.active_microscope.prepare_acquisition()
-                self.resume_data_thread()
-            else:
-                waveform_dict = self.active_microscope.calculate_all_waveform()
-
-            self.event_queue.put(("waveform", waveform_dict))
-
-            if self.is_acquiring:
-                # prepare devices based on updated info
-                # load features
-                self.signal_container, self.data_container = load_features(
-                    self, self.acquisition_modes_feature_setting[self.imaging_mode]
-                )
-                self.stop_send_signal = False
-                self.signal_thread = ThreadWithWarning(
-                    target=self.run_live_acquisition,
-                    warning_queue=self.event_queue,
-                    logger=self.logger,
-                )
-                self.signal_thread.name = "Waveform Popup Signal"
-                self.signal_thread.start()
+                self._start_resolution_setting_update()
+                return
+            self._update_setting(args[0])
 
         elif command == "autofocus":
             """Autofocus Routine
@@ -886,7 +851,12 @@ class Model:
 
         # print(self.configuration['experiment']['MirrorParameters']['modes'])
 
-    def move_stage(self, pos_dict: Dict[str, Any], wait_until_done=False) -> bool:
+    def move_stage(
+        self,
+        pos_dict: Dict[str, Any],
+        wait_until_done: bool = False,
+        cancel_event: Optional[threading.Event] = None,
+    ) -> bool:
         """Moves the stages.
 
         Updates the stage dictionary, moves to the desired position, and reports
@@ -898,6 +868,9 @@ class Model:
             Dictionary of stage positions.
         wait_until_done : bool
             Checks "on target state" after command and waits until done.
+        cancel_event : Optional[threading.Event], optional
+            Cooperative cancellation signal forwarded to the active microscope. The
+            caller remains responsible for issuing a hardware stage stop.
 
         Returns
         -------
@@ -906,7 +879,9 @@ class Model:
         """
         self.logger.debug("****** moving stage to: %s", pos_dict)
         try:
-            r = self.active_microscope.move_stage(pos_dict, wait_until_done)
+            r = self.active_microscope.move_stage(
+                pos_dict, wait_until_done, cancel_event=cancel_event
+            )
             self.logger.info(
                 f"Stage moved to:, {pos_dict}, " f"Wait until done: {wait_until_done}"
             )
@@ -943,12 +918,53 @@ class Model:
         microscope = self.microscopes[microscope_name]
         microscope.update_stage_limits()
 
-    def stop_stage(self) -> None:
-        """Stop the stages."""
-        self.active_microscope.stop_stage()
+    def stop_stage(self, *, cancel_resolution_change: bool = True) -> None:
+        """Stop stage motion and publish the actual stopped position.
+
+        Parameters
+        ----------
+        cancel_resolution_change : bool, optional
+            Cancel an active resolution-change task before stopping hardware. Internal
+            position refreshes at the successful end of a change pass ``False``.
+
+        Notes
+        -----
+        When a resolution change is active, cancellation is recorded before any
+        hardware stop call. Former, target, and active microscope configurations share
+        one device-ID set so each physical stage receives one best-effort stop attempt.
+        """
+        task = getattr(self, "_resolution_change_task", None)
+        if cancel_resolution_change and task is not None:
+            lock = getattr(self, "_resolution_change_lock", None)
+            if lock is None:
+                task.cancel_event.set()
+                task.state = "cancel_requested"
+            else:
+                with lock:
+                    task.cancel_event.set()
+                    task.state = "cancel_requested"
+
+        microscope_names = [self.active_microscope_name]
+        if cancel_resolution_change and task is not None:
+            microscope_names = [
+                task.former_microscope_name,
+                task.target_microscope_name,
+                self.active_microscope_name,
+            ]
+
+        stopped_stage_ids = set()
+        stop_errors = []
+        for microscope_name in dict.fromkeys(microscope_names):
+            stop_errors.extend(
+                self.microscopes[microscope_name].stop_stage(stopped_stage_ids)
+            )
+
         ret_pos_dict = self.get_stage_position()
         update_stage_dict(self, ret_pos_dict)
         self.event_queue.put(("update_stage", ret_pos_dict))
+        if cancel_resolution_change and task is not None:
+            task.stopped_position = ret_pos_dict
+            task.stop_errors.extend(stop_errors)
 
     def end_acquisition(self) -> None:
         """End the acquisition.
@@ -1499,26 +1515,202 @@ class Model:
             injected_flag.value = False
             self.event_queue.put(("autofocus_sequence_complete", None))
 
-    def change_resolution(self, resolution_value: str) -> None:
+    def _begin_resolution_change(
+        self, resolution_value: str
+    ) -> Optional[_ResolutionChangeTask]:
+        """Create the single active model-owned resolution task."""
+        with self._resolution_change_lock:
+            if self._resolution_change_task is not None:
+                self.event_queue.put(
+                    ("warning", "A resolution change is already in progress.")
+                )
+                return None
+            self._resolution_change_counter += 1
+            task = _ResolutionChangeTask(
+                task_id=self._resolution_change_counter,
+                resolution_value=resolution_value,
+                former_microscope_name=self.active_microscope_name,
+                target_microscope_name=resolution_value,
+            )
+            self._resolution_change_task = task
+            return task
+
+    def _finish_resolution_change(
+        self, task: _ResolutionChangeTask, succeeded: bool
+    ) -> None:
+        """Record terminal task state and release the active-task slot."""
+        cancelled = task.cancel_event.is_set()
+        task.state = "cancelled" if cancelled else "completed"
+        if cancelled:
+            self.event_queue.put(
+                (
+                    "resolution_change_cancelled",
+                    {
+                        "task_id": task.task_id,
+                        "microscope_name": self.active_microscope_name,
+                        "zoom": self.configuration["experiment"]["MicroscopeState"][
+                            "zoom"
+                        ],
+                        "previous_position": task.previous_position,
+                        "stopped_position": task.stopped_position,
+                        "return_allowed": False,
+                        "errors": list(task.stop_errors),
+                    },
+                )
+            )
+        elif not succeeded:
+            self.event_queue.put(("warning", "Resolution change did not complete."))
+        with self._resolution_change_lock:
+            if self._resolution_change_task is task:
+                self._resolution_change_task = None
+
+    def _perform_resolution_change(self, task: _ResolutionChangeTask) -> bool:
+        """Run the physical resolution change for a tracked task."""
+        return self._change_resolution(
+            task.resolution_value, cancel_event=task.cancel_event, task=task
+        )
+
+    def _start_resolution_setting_update(self) -> bool:
+        """Start a manual resolution update without occupying the proxy call."""
+        resolution_value = self.configuration["experiment"]["MicroscopeState"][
+            "microscope_name"
+        ]
+        task = self._begin_resolution_change(resolution_value)
+        if task is None:
+            return False
+        worker = ThreadWithWarning(
+            target=lambda: self._update_setting("resolution", task),
+            warning_queue=self.event_queue,
+            logger=self.logger,
+        )
+        worker.name = "Resolution Change"
+        task.worker = worker
+        worker.start()
+        return True
+
+    def _update_setting(
+        self,
+        setting: str,
+        resolution_task: Optional[_ResolutionChangeTask] = None,
+    ) -> None:
+        """Apply a waveform or resolution setting update."""
+        reboot = False
+        succeeded = False
+        microscope_name = self.configuration["experiment"]["MicroscopeState"][
+            "microscope_name"
+        ]
+        try:
+            if self.is_acquiring:
+                self.stop_send_signal = True
+                self.signal_thread.join()
+                if microscope_name != self.active_microscope_name:
+                    self.pause_data_thread()
+                    self.active_microscope.end_acquisition()
+                    reboot = True
+                self.active_microscope.current_channel = 0
+
+            if setting == "resolution":
+                if resolution_task is None:
+                    succeeded = self.change_resolution(microscope_name) is not False
+                else:
+                    succeeded = self._perform_resolution_change(resolution_task)
+                if (
+                    resolution_task is not None
+                    and resolution_task.cancel_event.is_set()
+                ):
+                    self.stop_acquisition = True
+                    self.stop_send_signal = True
+                    if reboot:
+                        self.resume_data_thread()
+                    return
+
+            if reboot:
+                waveform_dict = self.active_microscope.prepare_acquisition()
+                self.resume_data_thread()
+            else:
+                waveform_dict = self.active_microscope.calculate_all_waveform()
+
+            self.event_queue.put(("waveform", waveform_dict))
+
+            if self.is_acquiring:
+                self.signal_container, self.data_container = load_features(
+                    self, self.acquisition_modes_feature_setting[self.imaging_mode]
+                )
+                self.stop_send_signal = False
+                self.signal_thread = ThreadWithWarning(
+                    target=self.run_live_acquisition,
+                    warning_queue=self.event_queue,
+                    logger=self.logger,
+                )
+                self.signal_thread.name = "Waveform Popup Signal"
+                self.signal_thread.start()
+            succeeded = True
+        finally:
+            if resolution_task is not None:
+                self._finish_resolution_change(resolution_task, succeeded)
+
+    def change_resolution(self, resolution_value: str) -> bool:
         """Switch resolution mode of the microscope.
 
         Parameters
         ----------
         resolution_value : str
             Resolution mode.
+
+        Returns
+        -------
+        bool
+            ``True`` when microscope, zoom, and stage updates complete. ``False``
+            when a move fails or an internal resolution task is cancelled.
+
+        Notes
+        -----
+        Manual GUI changes use a model-owned worker around this operation. Callers
+        that require cancellation should use the existing resolution command rather
+        than starting a second movement lifecycle.
         """
+        return self._change_resolution(resolution_value)
+
+    def _change_resolution(
+        self,
+        resolution_value: str,
+        cancel_event: Optional[threading.Event] = None,
+        task: Optional[_ResolutionChangeTask] = None,
+    ) -> bool:
+        """Apply microscope and stage changes with cooperative cancellation."""
         self.active_microscope.central_focus = None
 
-        former_microscope = self.active_microscope_name
+        former_microscope = (
+            task.former_microscope_name
+            if task is not None
+            else self.active_microscope_name
+        )
+        if cancel_event is not None and cancel_event.is_set():
+            return False
+
         if resolution_value != self.active_microscope_name:
             self.get_active_microscope()
-            self.active_microscope.move_stage_offset(former_microscope)
+            if task is not None:
+                task.previous_position = {
+                    key.replace("_pos", "_abs"): value
+                    for key, value in self.get_stage_position().items()
+                }
+            if cancel_event is not None and cancel_event.is_set():
+                return False
+            if not self.active_microscope.move_stage_offset(
+                former_microscope, cancel_event=cancel_event
+            ):
+                return False
 
         # update zoom if possible
         try:
+            if cancel_event is not None and cancel_event.is_set():
+                return False
             curr_zoom = self.active_microscope.zoom.zoomvalue
             zoom_value = self.configuration["experiment"]["MicroscopeState"]["zoom"]
             self.active_microscope.zoom.set_zoom(zoom_value)
+            if cancel_event is not None and cancel_event.is_set():
+                return False
             self.logger.info(
                 f"Change zoom of {self.active_microscope_name} to {zoom_value}"
             )
@@ -1531,6 +1723,11 @@ class Model:
                 and self.active_microscope_name == former_microscope
                 and solvent in offsets.keys()
             ):
+                if task is not None and task.previous_position is None:
+                    task.previous_position = {
+                        key.replace("_pos", "_abs"): value
+                        for key, value in self.get_stage_position().items()
+                    }
                 # stop stages
                 self.active_microscope.stop_stage()
                 curr_pos = self.get_stage_position()
@@ -1539,17 +1736,26 @@ class Model:
                     shift_pos[f"{axis}_abs"] = curr_pos[f"{axis}_pos"] + float(
                         mags[curr_zoom][zoom_value]
                     )
-                self.move_stage(shift_pos, wait_until_done=True)
+                if not self.move_stage(
+                    shift_pos,
+                    wait_until_done=True,
+                    cancel_event=cancel_event,
+                ):
+                    return False
+            if cancel_event is not None and cancel_event.is_set():
+                return False
             # stop stages and update GUI
-            self.stop_stage()
+            self.stop_stage(cancel_resolution_change=False)
+            return True
 
         except ValueError as e:
             self.logger.debug(
                 f"Error changing microscope resolution:"
                 f".{self.active_microscope_name} - {e}"
             )
-
-        self.active_microscope.ask_stage_for_position = True
+            return False
+        finally:
+            self.active_microscope.ask_stage_for_position = True
 
     def get_camera_line_interval_and_exposure_time(
         self, exposure_time: float, number_of_pixel: int
@@ -1751,6 +1957,11 @@ class Model:
 
     def terminate(self) -> None:
         """Terminate the model."""
+        task = getattr(self, "_resolution_change_task", None)
+        if task is not None and task.worker is not None and task.worker.is_alive():
+            self.stop_stage()
+            if task.worker is not threading.current_thread():
+                task.worker.join()
         self.active_microscope.terminate()
         for microscope_name in self.virtual_microscopes:
             self.virtual_microscopes[microscope_name].terminate()

--- a/src/navigate/model/resolution_change.py
+++ b/src/navigate/model/resolution_change.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2021-2026  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+"""Private lifecycle state for model-owned resolution changes."""
+
+from dataclasses import dataclass, field
+import threading
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class _ResolutionChangeTask:
+    """Track one resolution change or recovery movement inside the model."""
+
+    task_id: int
+    resolution_value: str
+    former_microscope_name: str
+    target_microscope_name: str
+    cancel_event: threading.Event = field(default_factory=threading.Event)
+    state: str = "changing"
+    worker: Optional[threading.Thread] = None
+    previous_position: Optional[Dict[str, Any]] = None
+    stopped_position: Optional[Dict[str, Any]] = None
+    stop_errors: List[str] = field(default_factory=list)

--- a/test/controller/sub_controllers/test_stages.py
+++ b/test/controller/sub_controllers/test_stages.py
@@ -31,6 +31,7 @@
 #
 
 import pytest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call
 import numpy as np
 
@@ -330,13 +331,15 @@ def test_down_btn_handler(stage_controller, flip_x, flip_y, flip_z):
     stage_config["flip_z"] = False
 
 
-def test_stop_button_handler(stage_controller):
+def test_stop_button_handler_dispatches_immediately():
+    from navigate.controller.sub_controllers.stages import StageController
 
-    stage_controller.view.after = MagicMock()
+    parent_controller = MagicMock()
+    stage_controller = SimpleNamespace(parent_controller=parent_controller)
 
-    stage_controller.stop_button_handler()
+    StageController.stop_button_handler(stage_controller)
 
-    stage_controller.view.after.assert_called_once()
+    parent_controller.execute.assert_called_once_with("stop_stage")
 
 
 def test_position_callback(stage_controller):

--- a/test/controller/test_controller.py
+++ b/test/controller/test_controller.py
@@ -997,7 +997,10 @@ def test_stop_stage_retries_proxy_contention():
     def stop_stage():
         attempts.append("stop")
         if len(attempts) == 1:
-            raise RuntimeError("model pipe is busy")
+            raise RuntimeError(
+                "Two different threads tried to use the same "
+                "ObjectInSubprocess at the same time!"
+            )
 
     controller = Controller.__new__(Controller)
     controller.model = SimpleNamespace(stop_stage=stop_stage)
@@ -1005,6 +1008,30 @@ def test_stop_stage_retries_proxy_contention():
     controller.stop_stage()
 
     assert attempts == ["stop", "stop"]
+
+
+def test_stop_stage_does_not_retry_hardware_runtime_error():
+    from types import SimpleNamespace
+
+    import pytest
+
+    from navigate.controller.controller import Controller
+
+    attempts = []
+
+    def stop_stage():
+        attempts.append("stop")
+        if len(attempts) == 1:
+            raise RuntimeError("hardware stop failed")
+        raise AssertionError("hardware failure was incorrectly retried")
+
+    controller = Controller.__new__(Controller)
+    controller.model = SimpleNamespace(stop_stage=stop_stage)
+
+    with pytest.raises(RuntimeError, match="hardware stop failed"):
+        controller.stop_stage()
+
+    assert attempts == ["stop"]
 
 
 def test_update_stage_controller_silent(controller):

--- a/test/controller/test_controller.py
+++ b/test/controller/test_controller.py
@@ -588,6 +588,31 @@ def test_execute_resolution(controller):
     pass
 
 
+def test_execute_resolution_does_not_join_worker():
+    from types import SimpleNamespace
+
+    from navigate.controller.controller import Controller
+
+    worker = MagicMock()
+    controller = Controller.__new__(Controller)
+    controller.configuration_controller = SimpleNamespace(
+        microscope_list=["scope"],
+        microscope_name="scope",
+        get_zoom_value_list=lambda _name: ["1x"],
+    )
+    controller.menu_controller = SimpleNamespace(
+        resolution_value=SimpleNamespace(get=lambda: "scope 1x", set=MagicMock())
+    )
+    controller.change_microscope = MagicMock()
+    controller.threads_pool = SimpleNamespace(
+        createThread=MagicMock(return_value=worker)
+    )
+
+    controller.execute("resolution", "scope 1x")
+
+    worker.join.assert_not_called()
+
+
 def test_execute_set_save(controller):
 
     for save_data in [True, False]:
@@ -960,6 +985,26 @@ def test_stop_stage(controller):
     controller.model.stop_stage = MagicMock()
     controller.stop_stage()
     controller.model.stop_stage.assert_called_with()
+
+
+def test_stop_stage_retries_proxy_contention():
+    from types import SimpleNamespace
+
+    from navigate.controller.controller import Controller
+
+    attempts = []
+
+    def stop_stage():
+        attempts.append("stop")
+        if len(attempts) == 1:
+            raise RuntimeError("model pipe is busy")
+
+    controller = Controller.__new__(Controller)
+    controller.model = SimpleNamespace(stop_stage=stop_stage)
+
+    controller.stop_stage()
+
+    assert attempts == ["stop", "stop"]
 
 
 def test_update_stage_controller_silent(controller):

--- a/test/controller/test_stop_stage_button_bindings.py
+++ b/test/controller/test_stop_stage_button_bindings.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2021-2026  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+"""Headless regression tests for both visible Stop Stage buttons."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from navigate.controller.controller import Controller
+from navigate.controller.sub_controllers.stages import StageController
+
+
+class _InvokableButton:
+    """Store and invoke a configured callback without constructing a Tk widget."""
+
+    def __init__(self):
+        self.command = None
+
+    def configure(self, *, command=None, **_options):
+        self.command = command
+
+    config = configure
+
+    def invoke(self):
+        if self.command is None:
+            raise RuntimeError("button has no configured command")
+        self.command()
+
+
+def _build_headless_controller():
+    stage_stop_button = _InvokableButton()
+    stage_view = SimpleNamespace(
+        add_additional_stage=lambda _axis: None,
+        after=lambda _delay, callback: callback(),
+        get_buttons=lambda: {
+            "stop": stage_stop_button,
+            "joystick": _InvokableButton(),
+        },
+        get_variables=lambda: {},
+        stack_shortcuts=SimpleNamespace(
+            set_start_button=_InvokableButton(),
+            set_end_button=_InvokableButton(),
+        ),
+    )
+    acquisition_stop_button = _InvokableButton()
+    executed_commands = []
+    controller = SimpleNamespace(
+        channels_tab_controller=SimpleNamespace(
+            update_start_position=lambda: None,
+            update_end_position=lambda: None,
+        ),
+        configuration={
+            "configuration": {
+                "microscopes": {"scope": {"stage": {"joystick_axes": []}}}
+            },
+            "experiment": {"StageParameters": {}},
+        },
+        configuration_controller=SimpleNamespace(
+            microscope_name="scope",
+            stage_axes=[],
+            all_stage_axes=[],
+        ),
+        execute=executed_commands.append,
+        view=SimpleNamespace(
+            acquire_bar=SimpleNamespace(stop_stage=acquisition_stop_button)
+        ),
+    )
+
+    # These callbacks initialize unrelated stage state and require full GUI widgets.
+    with patch.multiple(
+        StageController,
+        bind_position_callbacks=lambda _self: None,
+        initialize=lambda _self: None,
+        set_hover_descriptions=lambda _self: None,
+    ):
+        controller.stage_controller = StageController(stage_view, controller)
+    Controller.update_acquire_control(controller)
+
+    return controller, stage_stop_button, acquisition_stop_button, executed_commands
+
+
+def test_stage_control_stop_button_click_dispatches_stop_stage():
+    _, stage_stop_button, _, executed_commands = _build_headless_controller()
+
+    stage_stop_button.invoke()
+
+    assert executed_commands == ["stop_stage"]
+
+
+def test_acquisition_bar_stop_button_click_dispatches_stop_stage():
+    _, _, acquisition_stop_button, executed_commands = _build_headless_controller()
+
+    acquisition_stop_button.invoke()
+
+    assert executed_commands == ["stop_stage"]

--- a/test/model/features/test_update_setting.py
+++ b/test/model/features/test_update_setting.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2021-2026  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+"""Tests for cancellable feature-driven setting updates."""
+
+import threading
+from queue import SimpleQueue
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from navigate.model.features.update_setting import ChangeResolution
+
+
+def make_change_resolution_model():
+    """Build the complete model contract consumed by ChangeResolution."""
+    task = SimpleNamespace(cancel_event=threading.Event())
+    model = MagicMock()
+    model.configuration = {
+        "configuration": {
+            "microscopes": {
+                "low": {"zoom": {"position": {"1x": {}}}},
+                "high": {"zoom": {"position": {"1x": {}}}},
+            }
+        },
+        "experiment": {
+            "CameraParameters": {
+                "low": {"img_x_pixels": 2048, "img_y_pixels": 2048},
+                "high": {"img_x_pixels": 2048, "img_y_pixels": 2048},
+            },
+            "MicroscopeState": {"microscope_name": "low", "zoom": "1x"},
+        },
+    }
+    model.active_microscope_name = "low"
+    model.active_microscope = MagicMock()
+    model.event_queue = SimpleQueue()
+    model._begin_resolution_change.return_value = task
+    model._perform_resolution_change.return_value = False
+    model.change_resolution.return_value = False
+    model.stop_acquisition = False
+    model.stop_send_signal = False
+    return model, task
+
+
+def test_change_resolution_feature_does_not_prepare_after_cancellation():
+    model, task = make_change_resolution_model()
+    feature = ChangeResolution(model, "high", "1x")
+
+    result = feature.signal_func()
+
+    assert result is False
+    assert model.stop_acquisition is True
+    assert model.stop_send_signal is True
+    model.active_microscope.prepare_acquisition.assert_not_called()
+    model.active_microscope.prepare_next_channel.assert_not_called()
+    assert model.event_queue.empty()
+    model._finish_resolution_change.assert_called_once_with(task, False)

--- a/test/model/test_resolution_change.py
+++ b/test/model/test_resolution_change.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2021-2026  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+"""Focused tests for cancellable resolution-change stage motion."""
+
+import threading
+
+
+class RecordingStage:
+    """Small stage double that records physical movement and stop attempts."""
+
+    def __init__(
+        self,
+        name,
+        calls,
+        *,
+        cancel_event_on_move=None,
+        stop_error=None,
+    ):
+        self.name = name
+        self.calls = calls
+        self.cancel_event_on_move = cancel_event_on_move
+        self.stop_error = stop_error
+
+    def move_absolute(self, position, wait_until_done=False):
+        self.calls.append(("move", self.name, position, wait_until_done))
+        if self.cancel_event_on_move is not None:
+            self.cancel_event_on_move.set()
+        return True
+
+    def stop(self):
+        self.calls.append(("stop", self.name))
+        if self.stop_error is not None:
+            raise self.stop_error
+
+
+def make_microscope_with_stages(*stage_axes):
+    """Build a real Microscope instance without starting hardware."""
+    from navigate.model.microscope import Microscope
+
+    microscope = Microscope.__new__(Microscope)
+    microscope.stages_list = list(stage_axes)
+    microscope.stages = {axis: stage for stage, axes in stage_axes for axis in axes}
+    microscope.cache_stage_positions = False
+    microscope.ask_stage_for_position = True
+    microscope.central_focus = 0.0
+    microscope.get_stage_position = lambda: {"f_pos": 0.0}
+    return microscope
+
+
+def test_move_stage_stops_before_second_device_after_cancellation():
+    cancel_event = threading.Event()
+    calls = []
+    first = RecordingStage("first", calls, cancel_event_on_move=cancel_event)
+    second = RecordingStage("second", calls)
+    microscope = make_microscope_with_stages((first, ["x"]), (second, ["z"]))
+
+    result = microscope.move_stage(
+        {"x_abs": 10.0, "z_abs": 20.0},
+        wait_until_done=True,
+        cancel_event=cancel_event,
+    )
+
+    assert result is False
+    assert calls == [("move", "first", {"x_abs": 10.0}, True)]
+
+
+def test_move_stage_offset_stops_before_second_device_after_cancellation():
+    cancel_event = threading.Event()
+    calls = []
+    first = RecordingStage("first", calls, cancel_event_on_move=cancel_event)
+    second = RecordingStage("second", calls)
+    microscope = make_microscope_with_stages((first, ["x"]), (second, ["z"]))
+    microscope.microscope_name = "target"
+    microscope.configuration = {
+        "configuration": {
+            "microscopes": {
+                "former": {"stage": {"x_offset": 0, "z_offset": 0}},
+                "target": {"stage": {"x_offset": 5, "z_offset": -2}},
+            }
+        }
+    }
+    microscope.get_stage_position = lambda: {
+        "x_pos": 10.0,
+        "z_pos": 20.0,
+        "f_pos": 0.0,
+    }
+
+    result = microscope.move_stage_offset("former", cancel_event=cancel_event)
+
+    assert result is False
+    assert calls == [("move", "first", {"x_abs": 15.0}, True)]
+
+
+def test_stop_stage_attempts_each_unique_device_after_error():
+    calls = []
+    shared = RecordingStage("shared", calls, stop_error=RuntimeError("stop failed"))
+    other = RecordingStage("other", calls)
+    microscope = make_microscope_with_stages(
+        (shared, ["x"]), (shared, ["y"]), (other, ["z"])
+    )
+
+    errors = microscope.stop_stage()
+
+    assert calls == [("stop", "shared"), ("stop", "other")]
+    assert len(errors) == 1
+    assert "stop failed" in errors[0]

--- a/test/model/test_resolution_change.py
+++ b/test/model/test_resolution_change.py
@@ -4,6 +4,8 @@
 """Focused tests for cancellable resolution-change stage motion."""
 
 import threading
+from queue import SimpleQueue
+from types import SimpleNamespace
 
 
 class RecordingStage:
@@ -105,3 +107,218 @@ def test_stop_stage_attempts_each_unique_device_after_error():
     assert calls == [("stop", "shared"), ("stop", "other")]
     assert len(errors) == 1
     assert "stop failed" in errors[0]
+
+
+class RecordingMicroscope:
+    """Microscope double that observes model cancellation before hardware stop."""
+
+    def __init__(self, name, task, calls):
+        self.name = name
+        self.task = task
+        self.calls = calls
+
+    def stop_stage(self, stopped_stage_ids=None):
+        self.calls.append((self.name, self.task.cancel_event.is_set()))
+        return []
+
+
+def make_model_for_stop():
+    """Build a real Model instance around deterministic microscope doubles."""
+    from navigate.model.model import Model
+
+    task = SimpleNamespace(
+        cancel_event=threading.Event(),
+        state="changing",
+        former_microscope_name="former",
+        target_microscope_name="target",
+        stopped_position=None,
+        stop_errors=[],
+    )
+    calls = []
+    model = Model.__new__(Model)
+    model._resolution_change_task = task
+    model._resolution_change_lock = threading.Lock()
+    model.microscopes = {
+        name: RecordingMicroscope(name, task, calls) for name in ("former", "target")
+    }
+    model.active_microscope_name = "target"
+    model.active_microscope = model.microscopes["target"]
+    model.get_stage_position = lambda: {"x_pos": 7.0, "f_pos": 1.0}
+    model.configuration = {"experiment": {"StageParameters": {"x": 0.0, "f": 0.0}}}
+    model.event_queue = SimpleQueue()
+    return model, task, calls
+
+
+def test_model_stop_records_cancellation_before_each_hardware_stop():
+    model, task, calls = make_model_for_stop()
+
+    model.stop_stage()
+
+    assert task.state == "cancel_requested"
+    assert calls == [("former", True), ("target", True)]
+
+
+def test_model_stop_publishes_actual_stopped_position():
+    model, task, _ = make_model_for_stop()
+
+    model.stop_stage()
+
+    assert task.stopped_position == {"x_pos": 7.0, "f_pos": 1.0}
+    assert model.event_queue.get_nowait() == (
+        "update_stage",
+        {"x_pos": 7.0, "f_pos": 1.0},
+    )
+
+
+def test_model_move_stage_forwards_cancellation_event():
+    from unittest.mock import MagicMock
+
+    from navigate.model.model import Model
+
+    cancel_event = threading.Event()
+    model = Model.__new__(Model)
+    model.logger = MagicMock()
+    model.active_microscope = MagicMock()
+    model.active_microscope.move_stage.return_value = False
+
+    result = model.move_stage(
+        {"x_abs": 4.0}, wait_until_done=True, cancel_event=cancel_event
+    )
+
+    assert result is False
+    model.active_microscope.move_stage.assert_called_once_with(
+        {"x_abs": 4.0}, True, cancel_event=cancel_event
+    )
+
+
+def test_manual_resolution_command_returns_while_model_worker_is_active():
+    from unittest.mock import MagicMock
+
+    from navigate.model.model import Model
+
+    move_started = threading.Event()
+    release_move = threading.Event()
+    command_returned = threading.Event()
+
+    def blocking_resolution_change(*_args):
+        move_started.set()
+        release_move.wait(1.0)
+        return True
+
+    model = Model.__new__(Model)
+    model.logger = MagicMock()
+    model.configuration = {
+        "experiment": {"MicroscopeState": {"microscope_name": "target", "zoom": "1x"}}
+    }
+    model.active_microscope_name = "former"
+    model.active_microscope = MagicMock()
+    model.active_microscope.calculate_all_waveform.return_value = {}
+    model.is_acquiring = False
+    model.data_buffer = [object()]
+    model.event_queue = SimpleQueue()
+    model._resolution_change_lock = threading.Lock()
+    model._resolution_change_task = None
+    model._resolution_change_counter = 0
+    model.change_resolution = blocking_resolution_change
+    model._perform_resolution_change = blocking_resolution_change
+
+    def run_command():
+        model.run_command("update_setting", "resolution")
+        command_returned.set()
+
+    caller = threading.Thread(target=run_command)
+    caller.start()
+    try:
+        assert move_started.wait(1.0)
+        assert command_returned.wait(0.1)
+    finally:
+        release_move.set()
+        caller.join(1.0)
+
+
+def test_resolution_task_stops_after_cancelled_offset_move():
+    from unittest.mock import MagicMock
+
+    from navigate.model.model import Model
+    from navigate.model.resolution_change import _ResolutionChangeTask
+
+    cancel_event = threading.Event()
+    former = MagicMock()
+    target = MagicMock()
+    target.central_focus = 0.0
+    target.ask_stage_for_position = False
+    target.zoom.zoomvalue = "1x"
+    target.zoom.stage_offsets = None
+
+    def cancel_during_offset(_former_name, *, cancel_event=None):
+        assert cancel_event is not None
+        cancel_event.set()
+        return False
+
+    target.move_stage_offset.side_effect = cancel_during_offset
+
+    model = Model.__new__(Model)
+    model.logger = MagicMock()
+    model.configuration = {
+        "configuration": {"microscopes": {"former": {}, "target": {}}},
+        "experiment": {
+            "MicroscopeState": {"microscope_name": "target", "zoom": "2x"},
+            "Saving": {"solvent": "water"},
+            "StageParameters": {"x": 0.0, "f": 0.0},
+        },
+    }
+    model.microscopes = {"former": former, "target": target}
+    model.active_microscope_name = "former"
+    model.active_microscope = former
+    model.get_stage_position = lambda: {"x_pos": 12.0, "f_pos": 3.0}
+    model.stop_stage = MagicMock()
+    task = _ResolutionChangeTask(
+        task_id=1,
+        resolution_value="target",
+        former_microscope_name="former",
+        target_microscope_name="target",
+        cancel_event=cancel_event,
+    )
+
+    result = model._perform_resolution_change(task)
+
+    assert result is False
+    assert task.previous_position == {"x_abs": 12.0, "f_abs": 3.0}
+    target.zoom.set_zoom.assert_not_called()
+    model.stop_stage.assert_not_called()
+
+
+def test_terminate_stops_and_joins_active_resolution_worker():
+    from unittest.mock import MagicMock
+
+    from navigate.model.model import Model
+    from navigate.model.resolution_change import _ResolutionChangeTask
+
+    model = Model.__new__(Model)
+    model.active_microscope = MagicMock()
+    model.virtual_microscopes = {}
+    task = _ResolutionChangeTask(
+        task_id=1,
+        resolution_value="target",
+        former_microscope_name="former",
+        target_microscope_name="target",
+    )
+    worker = threading.Thread(target=task.cancel_event.wait)
+    task.worker = worker
+    model._resolution_change_task = task
+
+    stop_calls = []
+
+    def stop_stage():
+        stop_calls.append("stop")
+        task.cancel_event.set()
+
+    model.stop_stage = stop_stage
+    worker.start()
+    try:
+        model.terminate()
+        assert stop_calls == ["stop"]
+        assert worker.is_alive() is False
+    finally:
+        task.cancel_event.set()
+        worker.join(1.0)

--- a/test/model/test_resolution_change.py
+++ b/test/model/test_resolution_change.py
@@ -136,6 +136,7 @@ def make_model_for_stop():
     )
     calls = []
     model = Model.__new__(Model)
+    model.logger = SimpleNamespace(exception=lambda *_args: None)
     model._resolution_change_task = task
     model._resolution_change_lock = threading.Lock()
     model.microscopes = {
@@ -168,6 +169,39 @@ def test_model_stop_publishes_actual_stopped_position():
         "update_stage",
         {"x_pos": 7.0, "f_pos": 1.0},
     )
+
+
+def test_model_stop_attempts_target_after_former_microscope_error():
+    model, task, calls = make_model_for_stop()
+
+    def fail_after_stop(_stopped_stage_ids=None):
+        calls.append(("former", task.cancel_event.is_set()))
+        raise RuntimeError("former position read failed")
+
+    model.microscopes["former"].stop_stage = fail_after_stop
+
+    model.stop_stage()
+
+    assert calls == [("former", True), ("target", True)]
+    assert any("former position read failed" in error for error in task.stop_errors)
+
+
+def test_model_stop_reports_position_readback_error_after_stop_attempts():
+    model, task, calls = make_model_for_stop()
+
+    def fail_readback():
+        raise RuntimeError("position readback failed")
+
+    model.get_stage_position = fail_readback
+
+    model.stop_stage()
+
+    assert calls == [("former", True), ("target", True)]
+    assert task.stopped_position is None
+    assert any("position readback failed" in error for error in task.stop_errors)
+    event, message = model.event_queue.get_nowait()
+    assert event == "warning"
+    assert "position readback failed" in message
 
 
 def test_model_move_stage_forwards_cancellation_event():
@@ -322,3 +356,36 @@ def test_terminate_stops_and_joins_active_resolution_worker():
     finally:
         task.cancel_event.set()
         worker.join(1.0)
+
+
+def test_failed_resolution_move_does_not_calculate_waveforms():
+    from unittest.mock import MagicMock
+
+    from navigate.model.model import Model
+    from navigate.model.resolution_change import _ResolutionChangeTask
+
+    model = Model.__new__(Model)
+    model.configuration = {
+        "experiment": {"MicroscopeState": {"microscope_name": "target", "zoom": "1x"}}
+    }
+    model.active_microscope_name = "former"
+    model.active_microscope = MagicMock()
+    model.is_acquiring = False
+    model.stop_acquisition = False
+    model.stop_send_signal = False
+    model.event_queue = SimpleQueue()
+    model._perform_resolution_change = MagicMock(return_value=False)
+    model._finish_resolution_change = MagicMock()
+    task = _ResolutionChangeTask(
+        task_id=1,
+        resolution_value="target",
+        former_microscope_name="former",
+        target_microscope_name="target",
+    )
+
+    model._update_setting("resolution", task)
+
+    model.active_microscope.calculate_all_waveform.assert_not_called()
+    assert model.stop_acquisition is True
+    assert model.stop_send_signal is True
+    model._finish_resolution_change.assert_called_once_with(task, False)


### PR DESCRIPTION
## Summary

- keep Tk responsive while a resolution change is running by removing the controller-side worker join
- dispatch Stop Stage without the former 250-ms debounce and retry only genuine ObjectInSubprocess contention
- own resolution changes in the model, record cancellation before hardware stop, and stop every unique stage device participating in the transition
- prevent later stage devices, waveform calculation, and acquisition restart after cancellation or movement failure
- apply the same lifecycle to feature-driven ChangeResolution operations and join active workers during model termination

## Safety behavior

Stop Stage now sets the active resolution task's cancellation event before attempting any hardware stop. Former, target, and active microscope configurations share a set of attempted stage device IDs, so shared hardware is stopped once and an error from one microscope cannot prevent attempts on the remaining devices. Movement loops check cancellation before and after each blocking stage call.

This PR independently fixes the collision hazard. A stacked follow-up will consume the terminal cancellation event and add the approved Keep Current Position / Return to Previous Position dialog.

## Reuse analysis

- [Design specification](https://github.com/TheDeanLab/navigate/blob/kdean/issue-486-stop-resolution-change/docs/superpowers/specs/2026-08-04-issue-486-resolution-change-cancellation-design.md)
- [Implementation plan](https://github.com/TheDeanLab/navigate/blob/kdean/issue-486-stop-resolution-change/docs/superpowers/plans/2026-08-04-issue-486-resolution-change-cancellation.md)
- The implementation extends Model.change_resolution, Model.stop_stage, Microscope.move_stage, Microscope.move_stage_offset, Controller.stop_stage, the existing model event queue, and the ChangeResolution feature.
- It does not add a second stage executor, public cancellation API, or hardware ownership path.
- No implementation-time deviation from the core safety design was required.

## Verification

- Black check: passed on all modified Python files
- Ruff: passed on all modified Python files with pre-existing E721 at src/navigate/model/features/update_setting.py:358 excluded
- Focused and relevant regression tests: 62 passed, 1 existing NumPy deprecation warning
- Regression coverage includes cancellation-before-stop ordering, unique-device best-effort stopping, position-readback failure, no second-device movement, nonblocking model command return, proxy retry discrimination, acquisition non-restart, and termination cleanup

The local macOS Python uses Aqua/AppKit Tk, so Homebrew Xvfb cannot isolate native GUI windows. The controller regression tests used here do not construct Tk; native GUI behavior remains for Windows CI and the stacked popup PR's Linux X11/Xvfb lane.

Closes #486
