### PR TITLE
Prevent unsafe autofocus scans and plot progress in real time

### DIFF
--- a/docs/superpowers/plans/2026-08-07-autofocus-bounds-realtime-plot.md
+++ b/docs/superpowers/plans/2026-08-07-autofocus-bounds-realtime-plot.md
@@ -1,0 +1,531 @@
+# Autofocus Bounds Validation and Real-Time Plot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reject unsafe autofocus trajectories with immediate, continuously refreshed popup feedback, then render autofocus measurements in real time without blocking acquisition.
+
+**Architecture:** A single internal scan-position planner will define frame counts, popup preflight, and model execution. The popup will perform advisory validation from current configuration while the model performs authoritative validation immediately before each knowable scan and treats failed moves as fatal. Real-time plotting will publish accumulated metric snapshots and use Tk-thread coalescing plus a persistent Matplotlib artist, with histogram-style blitting and a full-draw fallback.
+
+**Tech Stack:** Python, Tkinter/ttk, Matplotlib, NumPy/SciPy, pytest, Navigate's feature/event architecture.
+
+## Global Constraints
+
+- Implement and verify Tasks 1–4 before beginning any real-time plotting work.
+- Never shift, clamp, truncate, or otherwise rewrite an invalid trajectory.
+- When limits are enabled, execute the exact requested trajectory or reject it.
+- Do not queue an autofocus frame position when the associated stage move fails.
+- Keep all Tk and Matplotlib mutation on the Tk main thread.
+- Do not open native Tk windows on the active macOS desktop; use headless tests.
+- Preserve the current autofocus start/stop lifecycle and event names used for final results.
+
+## Reuse Analysis
+
+No new user-callable API is needed. Extend the existing `Autofocus` feature, `ValidatedSpinbox` error state, controller stage-update paths, event queue, and `HistogramController` rendering pattern. The internal scan planner replaces the duplicated arithmetic already present in `get_autofocus_frame_num`, `get_steps`, and signal execution; it does not introduce a parallel autofocus abstraction. Real-time updates extend the existing `autofocus` event payload contract with an explicit progress marker while preserving final fit/result delivery.
+
+---
+
+## Task 1: Establish the Focused Baseline
+
+**Files:**
+
+- Test: `test/model/features/test_autofocus.py`
+- Test: `test/controller/sub_controllers/test_autofocus.py`
+- Test: `test/controller/test_controller.py`
+- Test: `test/controller/sub_controllers/test_histogram.py`
+
+- [x] **Step 1: Run the existing focused autofocus tests**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/model/features/test_autofocus.py \
+  test/controller/sub_controllers/test_autofocus.py \
+  test/controller/test_controller.py -q
+```
+
+Expected: PASS. If an unrelated pre-existing failure appears, record it before editing and narrow the baseline to the directly affected tests.
+
+- [x] **Step 2: Run the existing histogram tests**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/controller/sub_controllers/test_histogram.py -q
+```
+
+Expected: PASS. These tests establish that the blitting pattern being reused is healthy before autofocus adopts it.
+
+## Task 2: Centralize Exact Autofocus Scan Planning
+
+**Files:**
+
+- Modify: `src/navigate/model/features/autofocus.py`
+- Test: `test/model/features/test_autofocus.py`
+
+- [ ] **Step 1: Write failing tests for exact planned positions**
+
+Add literal expected-position tests for the internal planner, including:
+
+```python
+assert plan_autofocus_positions(0, 500, 50) == tuple(range(-250, 251, 50))
+assert plan_autofocus_positions(0, 10, 2) == (-6, -4, -2, 0, 2, 4)
+```
+
+Also cover a non-zero center and a range that is not an exact multiple of the step size. Expected positions must be written independently rather than calculated with production helpers.
+
+- [ ] **Step 2: Run the planner tests and confirm the expected failure**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/model/features/test_autofocus.py -k 'plan_autofocus_positions' -q
+```
+
+Expected: FAIL because the shared planner does not exist.
+
+- [ ] **Step 3: Implement one internal pure planner**
+
+Add `plan_autofocus_positions(center, scan_range, step_size)` in `autofocus.py`. Preserve the current acquisition sequence exactly: compute `int(scan_range // step_size) + 1` frames, center the existing even/odd sequence on `center`, and return an immutable tuple.
+
+Update `get_autofocus_frame_num`, `get_steps`, and signal-position selection to derive their counts/targets from this planner instead of repeating arithmetic. Do not change scan ordering or fitting behavior.
+
+- [ ] **Step 4: Run the planner and existing model tests**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/model/features/test_autofocus.py -q
+```
+
+Expected: PASS.
+
+## Task 3: Add Authoritative Model Bounds and Move Validation
+
+**Files:**
+
+- Modify: `src/navigate/model/features/autofocus.py`
+- Test: `test/model/features/test_autofocus.py`
+
+- [ ] **Step 1: Write failing bounds-policy tests**
+
+Cover these cases with literal limits and expected error text:
+
+- an in-bounds trajectory;
+- lower-bound, upper-bound, and both-bound violations;
+- limits disabled;
+- coarse-only rejection before acquisition preparation;
+- fine-only rejection before acquisition preparation;
+- combined scan validates coarse initially and validates the measured-center fine path before its first move;
+- a valid move queues the achieved requested position; and
+- a `False` stage-move result raises a user-visible error and does not append to `autofocus_pos_queue`.
+
+- [ ] **Step 2: Run the new model safety tests and confirm the failures**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/model/features/test_autofocus.py -k 'bound or limit or failed_move' -q
+```
+
+Expected: FAIL on missing bounds validation and ignored move results.
+
+- [ ] **Step 3: Implement shared bounds diagnostics**
+
+Add internal helpers that:
+
+- compare the planned minimum and maximum with configured axis limits;
+- bypass only the configured soft-limit check when stage limits are disabled;
+- format one consistent message containing scan label, requested interval, allowed interval, and stage-axis label; and
+- avoid rounding away an actual violation.
+
+Use `focus-stage` for the focus axis and an axis-specific stage label for other supported stage autofocus axes.
+
+- [ ] **Step 4: Preflight immediately knowable model paths**
+
+Before acquisition preparation, read the selected stage-axis current position and reject an invalid coarse path, or an invalid fine-only path. For combined scans, validate only coarse at this point because the fine center is not yet known.
+
+Remote-focus autofocus retains its current non-stage behavior.
+
+- [ ] **Step 5: Validate the combined fine path at the transition**
+
+After coarse analysis determines the fine center, construct and validate the exact fine trajectory before its first stage move. Raise `UserVisibleException` with the shared diagnostic on failure.
+
+- [ ] **Step 6: Make failed moves fatal before queueing**
+
+Check the boolean return from each autofocus stage move, including restoration/final positioning. On `False`, raise `UserVisibleException` and do not put that target on `autofocus_pos_queue`.
+
+- [ ] **Step 7: Run all focused model tests**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/model/features/test_autofocus.py -q
+```
+
+Expected: PASS.
+
+## Task 4: Add Live Popup Bounds Feedback and Refresh Hooks
+
+**Files:**
+
+- Modify: `src/navigate/view/popups/autofocus_setting_popup.py`
+- Modify: `src/navigate/controller/sub_controllers/autofocus.py`
+- Modify: `src/navigate/controller/controller.py`
+- Test: `test/view/popups/test_autofocuspopup.py`
+- Test: `test/controller/sub_controllers/test_autofocus.py`
+- Test: `test/controller/test_controller.py`
+
+- [ ] **Step 1: Write failing popup-structure tests**
+
+Assert that the Scan Parameters frame exposes a blank warning variable/label on the row below Fine, spans the scan columns, and uses the active theme danger color when populated.
+
+- [ ] **Step 2: Write failing controller-validation tests**
+
+Test `refresh_bounds_validation()` with mocked stage state for:
+
+- valid coarse and fine-only scans;
+- invalid coarse and invalid fine-only scans;
+- combined coarse+fine showing only a knowable coarse error;
+- both immediately knowable scans invalid, with newline-separated messages;
+- limits disabled;
+- non-stage/remote-focus selection;
+- numeric spinbox errors remaining independent; and
+- correction clearing the warning and restoring only the bounds error state.
+
+Assert that only the offending Range spinbox uses `_toggle_error(True)`.
+
+- [ ] **Step 3: Write failing final-preflight tests**
+
+When Start Autofocus is clicked with an invalid path, assert that the controller shows an error dialog containing the inline diagnostic and does not call the parent controller's autofocus dispatch. A valid path must retain the current dispatch behavior.
+
+- [ ] **Step 4: Write failing stage-refresh-hook tests**
+
+Assert that an open autofocus controller refreshes after:
+
+- `update_stage_controller_silent` changes the selected axis position;
+- configured stage minimum or maximum changes; and
+- stage limits are enabled or disabled.
+
+The hook must be safe when the popup is closed or not initialized.
+
+- [ ] **Step 5: Run the new GUI/controller tests and confirm failure**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/view/popups/test_autofocuspopup.py \
+  test/controller/sub_controllers/test_autofocus.py \
+  test/controller/test_controller.py -k 'autofocus or stage_limit' -q
+```
+
+Expected: FAIL on missing warning widgets, validation, and refresh hooks.
+
+- [ ] **Step 6: Implement the reserved warning row**
+
+Add a `StringVar`-backed warning label at row 3 of the scan-parameter frame, spanning all scan columns. It is blank by default and uses the theme's danger foreground.
+
+- [ ] **Step 7: Implement advisory controller validation**
+
+Use the model's shared planner/diagnostic helpers with:
+
+- `ConfigurationController.get_stage_position_limits` for current min/max;
+- the configured `StageParameters` axis position and limits-enabled state; and
+- the current device/ref selection.
+
+Keep separate bounds-error bookkeeping so clearing a bounds violation cannot erase an unrelated numeric validation error. Call refresh from existing setting-variable traces and when the selected device/ref changes.
+
+- [ ] **Step 8: Add final controller preflight**
+
+At the start of `start_autofocus`, refresh bounds validation. If any immediately knowable path is invalid, show the shared message via `messagebox.showerror` and return before dispatch.
+
+- [ ] **Step 9: Add stage position/limit refresh hooks**
+
+Add one guarded helper in the main controller to refresh an existing autofocus popup controller. Invoke it after silent position updates, stage limit-value updates, and limit-enabled toggles. Keep the configuration's limits-enabled value synchronized before refreshing.
+
+- [ ] **Step 10: Run the full phase-1 focused suite**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/model/features/test_autofocus.py \
+  test/view/popups/test_autofocuspopup.py \
+  test/controller/sub_controllers/test_autofocus.py \
+  test/controller/test_controller.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Lint phase-1 changes**
+
+Run:
+
+```bash
+ruff check \
+  src/navigate/model/features/autofocus.py \
+  src/navigate/view/popups/autofocus_setting_popup.py \
+  src/navigate/controller/sub_controllers/autofocus.py \
+  src/navigate/controller/controller.py \
+  test/model/features/test_autofocus.py \
+  test/view/popups/test_autofocuspopup.py \
+  test/controller/sub_controllers/test_autofocus.py \
+  test/controller/test_controller.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 12: Commit the independently verified safety phase**
+
+```bash
+git add src/navigate/model/features/autofocus.py \
+  src/navigate/view/popups/autofocus_setting_popup.py \
+  src/navigate/controller/sub_controllers/autofocus.py \
+  src/navigate/controller/controller.py \
+  test/model/features/test_autofocus.py \
+  test/view/popups/test_autofocuspopup.py \
+  test/controller/sub_controllers/test_autofocus.py \
+  test/controller/test_controller.py
+git commit -m "Prevent unsafe autofocus stage trajectories"
+```
+
+Commit body must mention reuse of the existing planner lifecycle, validation widgets, and stage-update paths.
+
+## Task 5: Publish Incremental Autofocus Measurements
+
+**Files:**
+
+- Modify: `src/navigate/model/features/autofocus.py`
+- Test: `test/model/features/test_autofocus.py`
+
+- [ ] **Step 1: Write failing progress-event tests**
+
+For each successfully processed image, assert one progress event is published after entropy calculation. Assert that successive payload snapshots contain all measurements so far and are copied snapshots rather than aliases of mutable `plot_data`.
+
+- [ ] **Step 2: Run the progress tests and confirm failure**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/model/features/test_autofocus.py -k 'progress' -q
+```
+
+Expected: FAIL because only final autofocus results are currently emitted.
+
+- [ ] **Step 3: Emit explicit progress payloads**
+
+After appending each `[position, entropy]` measurement, publish an `autofocus` event whose payload explicitly identifies it as progress and contains a defensive snapshot of accumulated points. Do not include image arrays and do not wait for the GUI.
+
+Preserve the current final event's measured points, fitted curves, and peak information, with an explicit final marker so the controller does not confuse it with progress.
+
+- [ ] **Step 4: Run the model tests**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/model/features/test_autofocus.py -q
+```
+
+Expected: PASS.
+
+## Task 6: Coalesce Real-Time Plot Updates on the Tk Thread
+
+**Files:**
+
+- Modify: `src/navigate/controller/sub_controllers/autofocus.py`
+- Test: `test/controller/sub_controllers/test_autofocus.py`
+
+- [ ] **Step 1: Write failing coalescing and persistent-artist tests**
+
+Cover:
+
+- a progress event received off the Tk thread stores a pending snapshot and schedules at most one `after_idle` callback;
+- multiple events before the callback replace the pending data with the latest snapshot;
+- flushing occurs on the Tk thread;
+- one persistent measured-point artist is updated with `set_data`; and
+- repeated progress updates do not accumulate Line2D artists.
+
+- [ ] **Step 2: Run the new controller tests and confirm failure**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/controller/sub_controllers/test_autofocus.py -k 'progress or coalesc or persistent' -q
+```
+
+Expected: FAIL on missing pending-update state and persistent artist.
+
+- [ ] **Step 3: Implement latest-value-wins scheduling**
+
+Mirror `CameraViewController`/`HistogramController`:
+
+- store `_pending_autofocus_data`;
+- store one `_autofocus_after_id`;
+- use the popup's Tk widget `after_idle` to schedule `_flush_pending_autofocus_update`;
+- replace stale pending snapshots; and
+- catch/log rendering exceptions without affecting acquisition.
+
+- [ ] **Step 4: Initialize and update one measured-point artist**
+
+Create the points artist once when preparing the plot. Ordinary progress updates call `set_data` and do not clear axes, recreate the artist, or call `tight_layout`.
+
+- [ ] **Step 5: Run the coalescing/controller tests**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/controller/sub_controllers/test_autofocus.py -q
+```
+
+Expected: PASS.
+
+## Task 7: Add Histogram-Style Blitting, Fallback, and Final Rendering
+
+**Files:**
+
+- Modify: `src/navigate/controller/sub_controllers/autofocus.py`
+- Test: `test/controller/sub_controllers/test_autofocus.py`
+
+- [ ] **Step 1: Write failing rendering-path tests**
+
+Test:
+
+- capability detection for `copy_from_bbox`, `restore_region`, and `blit`;
+- cached-background restore, artist draw, and axes blit on an ordinary update;
+- cache invalidation after a draw/resize signal;
+- axis expansion causing a full draw and new background before later blits;
+- non-blit fallback using a normal nonblocking/full draw;
+- final render retaining every measured point and adding fit/peak overlays; and
+- cancellation leaving partial measured data visible.
+
+- [ ] **Step 2: Run the rendering tests and confirm failure**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/controller/sub_controllers/test_autofocus.py -k 'blit or background or axis or cancel or final_plot' -q
+```
+
+Expected: FAIL on missing blit state and cache lifecycle.
+
+- [ ] **Step 3: Implement blit capability and cache lifecycle**
+
+Mirror `HistogramController` names and behavior where practical:
+
+- `_blit_supported`;
+- `_autofocus_background`;
+- `_force_full_redraw`;
+- `_invalidate_blit_cache`;
+- a draw-event callback that refreshes the cache; and
+- full-draw fallback when the backend lacks required methods.
+
+- [ ] **Step 4: Implement controlled axis expansion**
+
+Expand x/y limits only when a new point falls outside the current visible interval. Axis changes invalidate the cache and perform one full draw. Subsequent in-range points resume blitting.
+
+- [ ] **Step 5: Preserve final overlays and cancellation state**
+
+On a final result, perform one full render containing the complete measured series plus fit curves and peak indicators. On cancellation, cancel any scheduled idle callback safely but leave the most recent measured data/artist visible.
+
+- [ ] **Step 6: Run all real-time plotting tests**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/model/features/test_autofocus.py \
+  test/controller/sub_controllers/test_autofocus.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Lint phase-2 changes**
+
+Run:
+
+```bash
+ruff check \
+  src/navigate/model/features/autofocus.py \
+  src/navigate/controller/sub_controllers/autofocus.py \
+  test/model/features/test_autofocus.py \
+  test/controller/sub_controllers/test_autofocus.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the independently verified plotting phase**
+
+```bash
+git add src/navigate/model/features/autofocus.py \
+  src/navigate/controller/sub_controllers/autofocus.py \
+  test/model/features/test_autofocus.py \
+  test/controller/sub_controllers/test_autofocus.py
+git commit -m "Plot autofocus measurements during acquisition"
+```
+
+Commit body must mention reuse of the existing event pump and histogram blitting pattern.
+
+## Task 8: Final Regression and Documentation Verification
+
+**Files:**
+
+- Verify: `docs/superpowers/specs/2026-08-07-autofocus-bounds-realtime-plot-design.md`
+- Verify: `docs/superpowers/plans/2026-08-07-autofocus-bounds-realtime-plot.md`
+- Verify: all files changed by Tasks 2–7
+
+- [ ] **Step 1: Run the complete focused regression set**
+
+Run:
+
+```bash
+/opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' \
+  test/model/features/test_autofocus.py \
+  test/view/popups/test_autofocuspopup.py \
+  test/controller/sub_controllers/test_autofocus.py \
+  test/controller/sub_controllers/test_histogram.py \
+  test/controller/test_controller.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run repository-configured lint on all changed Python files**
+
+Run `ruff check` on every changed Python source and test file. If the repository requires formatting, run `ruff format --check` on that same explicit list.
+
+- [ ] **Step 3: Inspect the final diff for scope and safety**
+
+Run:
+
+```bash
+git diff origin/develop...HEAD --check
+git diff origin/develop...HEAD --stat
+git status --short
+```
+
+Confirm that no generated artifacts, unrelated user changes, or speculative public APIs were introduced.
+
+- [ ] **Step 4: Re-read the issue acceptance path**
+
+Confirm from tests and code that:
+
+- the unsafe initial trajectory cannot prepare acquisition;
+- a combined fine scan cannot make its first move before exact validation;
+- moving the stage or changing/toggling limits refreshes the open popup;
+- final preflight blocks dispatch and explains why;
+- every processed metric can be displayed during acquisition; and
+- plotting failures cannot stop autofocus.
+
+- [ ] **Step 5: Commit any final test/document-only adjustments**
+
+Use an intentional commit message describing only the remaining scope. Do not squash or publish unless requested.

--- a/docs/superpowers/plans/2026-08-07-autofocus-bounds-realtime-plot.md
+++ b/docs/superpowers/plans/2026-08-07-autofocus-bounds-realtime-plot.md
@@ -4,7 +4,7 @@
 
 **Goal:** Reject unsafe autofocus trajectories with immediate, continuously refreshed popup feedback, then render autofocus measurements in real time without blocking acquisition.
 
-**Architecture:** A single internal scan-position planner will define frame counts, popup preflight, and model execution. The popup will perform advisory validation from current configuration while the model performs authoritative validation immediately before each knowable scan and treats failed moves as fatal. Real-time plotting will publish accumulated metric snapshots and use Tk-thread coalescing plus a persistent Matplotlib artist, with histogram-style blitting and a full-draw fallback.
+**Architecture:** A single internal scan-position planner will define frame counts, popup preflight, and model execution. The popup will perform advisory validation from current configuration while the model performs authoritative validation immediately before each knowable scan and treats failed moves as fatal. Real-time plotting will publish accumulated metric snapshots through a dedicated one-slot queue and use Tk-thread coalescing plus a persistent Matplotlib artist, with histogram-style blitting and a full-draw fallback. Popup-independent calibration processing preserves completion bookkeeping if the window is closed mid-run.
 
 **Tech Stack:** Python, Tkinter/ttk, Matplotlib, NumPy/SciPy, pytest, Navigate's feature/event architecture.
 
@@ -20,7 +20,7 @@
 
 ## Reuse Analysis
 
-No new user-callable API is needed. Extend the existing `Autofocus` feature, `ValidatedSpinbox` error state, controller stage-update paths, event queue, and `HistogramController` rendering pattern. The internal scan planner replaces the duplicated arithmetic already present in `get_autofocus_frame_num`, `get_steps`, and signal execution; it does not introduce a parallel autofocus abstraction. Real-time updates extend the existing `autofocus` event payload contract with an explicit progress marker while preserving final fit/result delivery.
+No new user-callable API is needed. Extend the existing `Autofocus` feature, `ValidatedSpinbox` error state, controller stage-update paths, event pump, and `HistogramController` rendering pattern. The internal scan planner replaces the duplicated arithmetic already present in `get_autofocus_frame_num`, `get_steps`, and signal execution; it does not introduce a parallel autofocus abstraction. Replaceable real-time updates use a dedicated one-slot transport so final fit/results, warnings, and completion metadata retain reliable queue capacity.
 
 ---
 
@@ -529,3 +529,27 @@ Confirm from tests and code that:
 - [x] **Step 5: Commit any final test/document-only adjustments**
 
 Use an intentional commit message describing only the remaining scope. Do not squash or publish unless requested.
+
+## Task 9: Review Hardening for Event Reliability and Popup Lifetime
+
+- [x] **Step 1: Reproduce reliable-event starvation and close-mid-calibration**
+
+Add failing tests for a saturated progress transport followed by final delivery,
+and for reference capture after the autofocus popup has been destroyed.
+
+- [x] **Step 2: Isolate replaceable progress**
+
+Pass a dedicated one-slot multiprocessing queue to the model. Replace a stale
+snapshot without blocking, and have the existing Tk event pump drain only the
+newest snapshot before reliable events.
+
+- [x] **Step 3: Separate completion processing from popup lifetime**
+
+Keep defocus-calibration reference and configuration updates in a persistent
+main-controller-owned object. Limit popup event registration to view-specific
+plot events.
+
+- [x] **Step 4: Run focused regressions and lint**
+
+Verify model autofocus, popup controller, main controller, the complete focused
+suite, Ruff, and `git diff --check` before requesting final review.

--- a/docs/superpowers/plans/2026-08-07-autofocus-bounds-realtime-plot.md
+++ b/docs/superpowers/plans/2026-08-07-autofocus-bounds-realtime-plot.md
@@ -464,7 +464,7 @@ ruff check \
 
 Expected: PASS.
 
-- [ ] **Step 8: Commit the independently verified plotting phase**
+- [x] **Step 8: Commit the independently verified plotting phase**
 
 ```bash
 git add src/navigate/model/features/autofocus.py \
@@ -484,7 +484,7 @@ Commit body must mention reuse of the existing event pump and histogram blitting
 - Verify: `docs/superpowers/plans/2026-08-07-autofocus-bounds-realtime-plot.md`
 - Verify: all files changed by Tasks 2–7
 
-- [ ] **Step 1: Run the complete focused regression set**
+- [x] **Step 1: Run the complete focused regression set**
 
 Run:
 
@@ -499,11 +499,11 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 2: Run repository-configured lint on all changed Python files**
+- [x] **Step 2: Run repository-configured lint on all changed Python files**
 
 Run `ruff check` on every changed Python source and test file. If the repository requires formatting, run `ruff format --check` on that same explicit list.
 
-- [ ] **Step 3: Inspect the final diff for scope and safety**
+- [x] **Step 3: Inspect the final diff for scope and safety**
 
 Run:
 
@@ -515,7 +515,7 @@ git status --short
 
 Confirm that no generated artifacts, unrelated user changes, or speculative public APIs were introduced.
 
-- [ ] **Step 4: Re-read the issue acceptance path**
+- [x] **Step 4: Re-read the issue acceptance path**
 
 Confirm from tests and code that:
 
@@ -526,6 +526,6 @@ Confirm from tests and code that:
 - every processed metric can be displayed during acquisition; and
 - plotting failures cannot stop autofocus.
 
-- [ ] **Step 5: Commit any final test/document-only adjustments**
+- [x] **Step 5: Commit any final test/document-only adjustments**
 
 Use an intentional commit message describing only the remaining scope. Do not squash or publish unless requested.

--- a/docs/superpowers/plans/2026-08-07-autofocus-bounds-realtime-plot.md
+++ b/docs/superpowers/plans/2026-08-07-autofocus-bounds-realtime-plot.md
@@ -64,7 +64,7 @@ Expected: PASS. These tests establish that the blitting pattern being reused is 
 - Modify: `src/navigate/model/features/autofocus.py`
 - Test: `test/model/features/test_autofocus.py`
 
-- [ ] **Step 1: Write failing tests for exact planned positions**
+- [x] **Step 1: Write failing tests for exact planned positions**
 
 Add literal expected-position tests for the internal planner, including:
 
@@ -75,7 +75,7 @@ assert plan_autofocus_positions(0, 10, 2) == (-6, -4, -2, 0, 2, 4)
 
 Also cover a non-zero center and a range that is not an exact multiple of the step size. Expected positions must be written independently rather than calculated with production helpers.
 
-- [ ] **Step 2: Run the planner tests and confirm the expected failure**
+- [x] **Step 2: Run the planner tests and confirm the expected failure**
 
 Run:
 
@@ -86,13 +86,13 @@ Run:
 
 Expected: FAIL because the shared planner does not exist.
 
-- [ ] **Step 3: Implement one internal pure planner**
+- [x] **Step 3: Implement one internal pure planner**
 
 Add `plan_autofocus_positions(center, scan_range, step_size)` in `autofocus.py`. Preserve the current acquisition sequence exactly: compute `int(scan_range // step_size) + 1` frames, center the existing even/odd sequence on `center`, and return an immutable tuple.
 
 Update `get_autofocus_frame_num`, `get_steps`, and signal-position selection to derive their counts/targets from this planner instead of repeating arithmetic. Do not change scan ordering or fitting behavior.
 
-- [ ] **Step 4: Run the planner and existing model tests**
+- [x] **Step 4: Run the planner and existing model tests**
 
 Run:
 
@@ -110,7 +110,7 @@ Expected: PASS.
 - Modify: `src/navigate/model/features/autofocus.py`
 - Test: `test/model/features/test_autofocus.py`
 
-- [ ] **Step 1: Write failing bounds-policy tests**
+- [x] **Step 1: Write failing bounds-policy tests**
 
 Cover these cases with literal limits and expected error text:
 
@@ -123,7 +123,7 @@ Cover these cases with literal limits and expected error text:
 - a valid move queues the achieved requested position; and
 - a `False` stage-move result raises a user-visible error and does not append to `autofocus_pos_queue`.
 
-- [ ] **Step 2: Run the new model safety tests and confirm the failures**
+- [x] **Step 2: Run the new model safety tests and confirm the failures**
 
 Run:
 
@@ -134,7 +134,7 @@ Run:
 
 Expected: FAIL on missing bounds validation and ignored move results.
 
-- [ ] **Step 3: Implement shared bounds diagnostics**
+- [x] **Step 3: Implement shared bounds diagnostics**
 
 Add internal helpers that:
 
@@ -145,21 +145,21 @@ Add internal helpers that:
 
 Use `focus-stage` for the focus axis and an axis-specific stage label for other supported stage autofocus axes.
 
-- [ ] **Step 4: Preflight immediately knowable model paths**
+- [x] **Step 4: Preflight immediately knowable model paths**
 
 Before acquisition preparation, read the selected stage-axis current position and reject an invalid coarse path, or an invalid fine-only path. For combined scans, validate only coarse at this point because the fine center is not yet known.
 
 Remote-focus autofocus retains its current non-stage behavior.
 
-- [ ] **Step 5: Validate the combined fine path at the transition**
+- [x] **Step 5: Validate the combined fine path at the transition**
 
 After coarse analysis determines the fine center, construct and validate the exact fine trajectory before its first stage move. Raise `UserVisibleException` with the shared diagnostic on failure.
 
-- [ ] **Step 6: Make failed moves fatal before queueing**
+- [x] **Step 6: Make failed moves fatal before queueing**
 
 Check the boolean return from each autofocus stage move, including restoration/final positioning. On `False`, raise `UserVisibleException` and do not put that target on `autofocus_pos_queue`.
 
-- [ ] **Step 7: Run all focused model tests**
+- [x] **Step 7: Run all focused model tests**
 
 Run:
 
@@ -181,11 +181,11 @@ Expected: PASS.
 - Test: `test/controller/sub_controllers/test_autofocus.py`
 - Test: `test/controller/test_controller.py`
 
-- [ ] **Step 1: Write failing popup-structure tests**
+- [x] **Step 1: Write failing popup-structure tests**
 
 Assert that the Scan Parameters frame exposes a blank warning variable/label on the row below Fine, spans the scan columns, and uses the active theme danger color when populated.
 
-- [ ] **Step 2: Write failing controller-validation tests**
+- [x] **Step 2: Write failing controller-validation tests**
 
 Test `refresh_bounds_validation()` with mocked stage state for:
 
@@ -200,11 +200,11 @@ Test `refresh_bounds_validation()` with mocked stage state for:
 
 Assert that only the offending Range spinbox uses `_toggle_error(True)`.
 
-- [ ] **Step 3: Write failing final-preflight tests**
+- [x] **Step 3: Write failing final-preflight tests**
 
 When Start Autofocus is clicked with an invalid path, assert that the controller shows an error dialog containing the inline diagnostic and does not call the parent controller's autofocus dispatch. A valid path must retain the current dispatch behavior.
 
-- [ ] **Step 4: Write failing stage-refresh-hook tests**
+- [x] **Step 4: Write failing stage-refresh-hook tests**
 
 Assert that an open autofocus controller refreshes after:
 
@@ -214,7 +214,7 @@ Assert that an open autofocus controller refreshes after:
 
 The hook must be safe when the popup is closed or not initialized.
 
-- [ ] **Step 5: Run the new GUI/controller tests and confirm failure**
+- [x] **Step 5: Run the new GUI/controller tests and confirm failure**
 
 Run:
 
@@ -227,11 +227,11 @@ Run:
 
 Expected: FAIL on missing warning widgets, validation, and refresh hooks.
 
-- [ ] **Step 6: Implement the reserved warning row**
+- [x] **Step 6: Implement the reserved warning row**
 
 Add a `StringVar`-backed warning label at row 3 of the scan-parameter frame, spanning all scan columns. It is blank by default and uses the theme's danger foreground.
 
-- [ ] **Step 7: Implement advisory controller validation**
+- [x] **Step 7: Implement advisory controller validation**
 
 Use the model's shared planner/diagnostic helpers with:
 
@@ -241,15 +241,15 @@ Use the model's shared planner/diagnostic helpers with:
 
 Keep separate bounds-error bookkeeping so clearing a bounds violation cannot erase an unrelated numeric validation error. Call refresh from existing setting-variable traces and when the selected device/ref changes.
 
-- [ ] **Step 8: Add final controller preflight**
+- [x] **Step 8: Add final controller preflight**
 
 At the start of `start_autofocus`, refresh bounds validation. If any immediately knowable path is invalid, show the shared message via `messagebox.showerror` and return before dispatch.
 
-- [ ] **Step 9: Add stage position/limit refresh hooks**
+- [x] **Step 9: Add stage position/limit refresh hooks**
 
 Add one guarded helper in the main controller to refresh an existing autofocus popup controller. Invoke it after silent position updates, stage limit-value updates, and limit-enabled toggles. Keep the configuration's limits-enabled value synchronized before refreshing.
 
-- [ ] **Step 10: Run the full phase-1 focused suite**
+- [x] **Step 10: Run the full phase-1 focused suite**
 
 Run:
 
@@ -263,7 +263,7 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 11: Lint phase-1 changes**
+- [x] **Step 11: Lint phase-1 changes**
 
 Run:
 

--- a/docs/superpowers/plans/2026-08-07-autofocus-bounds-realtime-plot.md
+++ b/docs/superpowers/plans/2026-08-07-autofocus-bounds-realtime-plot.md
@@ -281,7 +281,7 @@ ruff check \
 
 Expected: PASS.
 
-- [ ] **Step 12: Commit the independently verified safety phase**
+- [x] **Step 12: Commit the independently verified safety phase**
 
 ```bash
 git add src/navigate/model/features/autofocus.py \
@@ -304,11 +304,11 @@ Commit body must mention reuse of the existing planner lifecycle, validation wid
 - Modify: `src/navigate/model/features/autofocus.py`
 - Test: `test/model/features/test_autofocus.py`
 
-- [ ] **Step 1: Write failing progress-event tests**
+- [x] **Step 1: Write failing progress-event tests**
 
 For each successfully processed image, assert one progress event is published after entropy calculation. Assert that successive payload snapshots contain all measurements so far and are copied snapshots rather than aliases of mutable `plot_data`.
 
-- [ ] **Step 2: Run the progress tests and confirm failure**
+- [x] **Step 2: Run the progress tests and confirm failure**
 
 Run:
 
@@ -319,13 +319,13 @@ Run:
 
 Expected: FAIL because only final autofocus results are currently emitted.
 
-- [ ] **Step 3: Emit explicit progress payloads**
+- [x] **Step 3: Emit explicit progress payloads**
 
 After appending each `[position, entropy]` measurement, publish an `autofocus` event whose payload explicitly identifies it as progress and contains a defensive snapshot of accumulated points. Do not include image arrays and do not wait for the GUI.
 
 Preserve the current final event's measured points, fitted curves, and peak information, with an explicit final marker so the controller does not confuse it with progress.
 
-- [ ] **Step 4: Run the model tests**
+- [x] **Step 4: Run the model tests**
 
 Run:
 
@@ -343,7 +343,7 @@ Expected: PASS.
 - Modify: `src/navigate/controller/sub_controllers/autofocus.py`
 - Test: `test/controller/sub_controllers/test_autofocus.py`
 
-- [ ] **Step 1: Write failing coalescing and persistent-artist tests**
+- [x] **Step 1: Write failing coalescing and persistent-artist tests**
 
 Cover:
 
@@ -353,7 +353,7 @@ Cover:
 - one persistent measured-point artist is updated with `set_data`; and
 - repeated progress updates do not accumulate Line2D artists.
 
-- [ ] **Step 2: Run the new controller tests and confirm failure**
+- [x] **Step 2: Run the new controller tests and confirm failure**
 
 Run:
 
@@ -364,7 +364,7 @@ Run:
 
 Expected: FAIL on missing pending-update state and persistent artist.
 
-- [ ] **Step 3: Implement latest-value-wins scheduling**
+- [x] **Step 3: Implement latest-value-wins scheduling**
 
 Mirror `CameraViewController`/`HistogramController`:
 
@@ -374,11 +374,11 @@ Mirror `CameraViewController`/`HistogramController`:
 - replace stale pending snapshots; and
 - catch/log rendering exceptions without affecting acquisition.
 
-- [ ] **Step 4: Initialize and update one measured-point artist**
+- [x] **Step 4: Initialize and update one measured-point artist**
 
 Create the points artist once when preparing the plot. Ordinary progress updates call `set_data` and do not clear axes, recreate the artist, or call `tight_layout`.
 
-- [ ] **Step 5: Run the coalescing/controller tests**
+- [x] **Step 5: Run the coalescing/controller tests**
 
 Run:
 
@@ -396,7 +396,7 @@ Expected: PASS.
 - Modify: `src/navigate/controller/sub_controllers/autofocus.py`
 - Test: `test/controller/sub_controllers/test_autofocus.py`
 
-- [ ] **Step 1: Write failing rendering-path tests**
+- [x] **Step 1: Write failing rendering-path tests**
 
 Test:
 
@@ -408,7 +408,7 @@ Test:
 - final render retaining every measured point and adding fit/peak overlays; and
 - cancellation leaving partial measured data visible.
 
-- [ ] **Step 2: Run the rendering tests and confirm failure**
+- [x] **Step 2: Run the rendering tests and confirm failure**
 
 Run:
 
@@ -419,7 +419,7 @@ Run:
 
 Expected: FAIL on missing blit state and cache lifecycle.
 
-- [ ] **Step 3: Implement blit capability and cache lifecycle**
+- [x] **Step 3: Implement blit capability and cache lifecycle**
 
 Mirror `HistogramController` names and behavior where practical:
 
@@ -430,15 +430,15 @@ Mirror `HistogramController` names and behavior where practical:
 - a draw-event callback that refreshes the cache; and
 - full-draw fallback when the backend lacks required methods.
 
-- [ ] **Step 4: Implement controlled axis expansion**
+- [x] **Step 4: Implement controlled axis expansion**
 
 Expand x/y limits only when a new point falls outside the current visible interval. Axis changes invalidate the cache and perform one full draw. Subsequent in-range points resume blitting.
 
-- [ ] **Step 5: Preserve final overlays and cancellation state**
+- [x] **Step 5: Preserve final overlays and cancellation state**
 
 On a final result, perform one full render containing the complete measured series plus fit curves and peak indicators. On cancellation, cancel any scheduled idle callback safely but leave the most recent measured data/artist visible.
 
-- [ ] **Step 6: Run all real-time plotting tests**
+- [x] **Step 6: Run all real-time plotting tests**
 
 Run:
 
@@ -450,7 +450,7 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 7: Lint phase-2 changes**
+- [x] **Step 7: Lint phase-2 changes**
 
 Run:
 

--- a/docs/superpowers/specs/2026-08-07-autofocus-bounds-realtime-plot-design.md
+++ b/docs/superpowers/specs/2026-08-07-autofocus-bounds-realtime-plot-design.md
@@ -102,6 +102,12 @@ autofocus-progress event containing the accumulated position/metric data. It
 will not publish image pixels for plotting. Acquisition and metric calculation
 must not wait for the GUI.
 
+Progress uses a dedicated, single-slot multiprocessing queue. When the slot is
+occupied, the model replaces the stale snapshot with the newest cumulative
+snapshot. Replaceable progress therefore cannot consume capacity in the
+reliable event queue used for final plots, warnings, stage updates, and
+completion metadata.
+
 The popup controller will follow the image-display and histogram "latest value
 wins" pattern:
 
@@ -135,11 +141,16 @@ data.
 ## Event and Thread Boundaries
 
 The model data thread owns focus-metric calculation and progress publication.
-The main controller's existing event pump transfers progress to the popup
-controller. All Tk and Matplotlib artist mutation occurs on the Tk main thread.
-Progress events are snapshots and may be coalesced for display; the model's
-authoritative `plot_data` retains every measurement for fitting and final
-reporting.
+The main controller's existing event pump drains the latest progress snapshot
+and transfers it to the popup controller. All Tk and Matplotlib artist mutation
+occurs on the Tk main thread. Progress events are snapshots and may be
+coalesced for display; the model's authoritative `plot_data` retains every
+measurement for fitting and final reporting.
+
+Autofocus completion metadata is handled by a persistent calibration
+controller owned by the main controller. The popup only owns view-specific
+plot handlers, so closing and destroying it cannot suppress capture-reference
+or populate-defocus configuration updates.
 
 ## Error Handling
 
@@ -171,13 +182,15 @@ Phase 1 tests will cover:
 Phase 2 tests will cover:
 
 - one progress publication per processed autofocus measurement;
+- stale progress replacement without occupying the reliable event queue;
 - snapshots retaining every calculated point;
 - coalescing multiple pending updates into the newest dataset;
 - persistent artist updates without artist accumulation;
 - the blit path, cache invalidation, and non-blit fallback;
 - axis expansion causing a full redraw before blitting resumes;
-- final fit and peak overlays; and
-- cancellation preserving the partial plot.
+- final fit and peak overlays;
+- cancellation preserving the partial plot; and
+- completion bookkeeping after the popup is closed mid-calibration.
 
 Focused model and controller tests will run after each phase. No native Tk
 windows will be opened on the active macOS desktop; GUI behavior will be
@@ -188,14 +201,14 @@ covered by the repository's headless controller/view tests.
 This design extends existing mechanisms rather than adding parallel lifecycle
 or rendering abstractions:
 
-- retain the existing Autofocus feature and event queue;
+- retain the existing Autofocus feature and reliable event queue;
 - centralize and reuse its current step/range calculation instead of adding a
   second scan algorithm;
 - use `ConfigurationController.get_stage_position_limits` and existing stage
   limit state as the controller authority;
 - use `ValidatedSpinbox` error coloring and the active theme's danger color;
 - refresh from the existing stage-position and stage-limit update paths;
-- reuse the controller event pump for progress delivery; and
+- reuse the controller event pump with a dedicated latest-progress slot; and
 - mirror `HistogramController`'s `after_idle` coalescing, persistent artist,
   background invalidation, blitting, and fallback behavior.
 

--- a/docs/superpowers/specs/2026-08-07-autofocus-bounds-realtime-plot-design.md
+++ b/docs/superpowers/specs/2026-08-07-autofocus-bounds-realtime-plot-design.md
@@ -1,0 +1,202 @@
+# Autofocus Bounds Validation and Real-Time Plot Design
+
+## Purpose
+
+Resolve GitHub issue #315 by preventing autofocus from commanding focus-stage
+positions outside enabled stage limits. Give users immediate, continuously
+updated feedback in the Autofocus Settings popup, while retaining a final
+fail-closed check before acquisition. After the bounds work is independently
+tested, update the autofocus graph as each image's focus metric becomes
+available without slowing acquisition.
+
+## Delivery Order
+
+The work has two sequential phases:
+
+1. Implement bounds planning, live popup validation, and model-side safety
+   checks. Complete focused tests before starting phase 2.
+2. Implement coalesced real-time plot updates using the existing histogram
+   blitting pattern and complete a separate set of focused tests.
+
+The phases may share internal scan-planning data, but phase 2 must not be used
+to justify weakening or postponing phase 1 safety checks.
+
+## Scan Planning and Bounds Policy
+
+Autofocus will construct the exact sequence of requested positions before it
+moves a stage. The same internal planning function will be used for frame
+counts, popup validation, and signal execution so the displayed bounds and
+executed path cannot disagree.
+
+When stage limits are enabled, every planned position must lie within the
+selected stage axis's configured minimum and maximum. If any position is
+outside that interval, autofocus will not shift, clamp, truncate, or otherwise
+alter the trajectory. It will reject the scan before the first affected move.
+This preserves the user's intended motion envelope and avoids duplicate
+measurements at a clamped boundary.
+
+The controller check provides early feedback, but the model remains
+authoritative. Model-side validation protects autofocus started through other
+entry points and handles configuration or position changes between the popup
+check and acquisition. A stage move that returns `False` is also a hard failure:
+the associated frame position must not be placed on the autofocus processing
+queue.
+
+If software stage limits are disabled, configured soft limits do not block the
+scan. Individual device or hardware failures still abort autofocus through the
+failed-move check.
+
+### Coarse and Fine Centers
+
+- A coarse scan is centered on the current selected stage-axis position and can
+  be validated immediately.
+- A fine-only scan is centered on the current selected stage-axis position and
+  can be validated immediately.
+- When coarse and fine scans are both selected, the fine center is the measured
+  coarse result and is not known before acquisition. The popup will validate
+  the coarse path immediately. After the coarse result is available, the model
+  will construct and validate the exact fine path before its first move. If it
+  is invalid, autofocus stops safely and reports the fine-scan bounds error.
+
+The popup must not show a definitive fine-scan error based on an assumed coarse
+result. That would be misleading. The final model-side check guarantees safety
+at the point where the fine center becomes known.
+
+## Immediate Popup Feedback
+
+The Scan Parameters panel will reserve a warning row directly below the Fine
+row. A themed label spanning the panel columns will normally be blank. When an
+immediately knowable scan is invalid, it will show red text such as:
+
+> The requested coarse scan (-250 to 250 µm) exceeds the focus-stage limits
+> (0 to 1000 µm).
+
+The offending scan's Range spinbox text will use the existing validation danger
+color. The Step Size spinbox will retain its normal color unless its own numeric
+validation fails. If both immediately knowable scans are invalid, the warning
+row will show both messages on separate lines and both Range spinboxes will be
+red.
+
+Validation will refresh when any relevant state changes:
+
+- coarse or fine selection, range, or step size;
+- selected autofocus device or axis;
+- current position of the selected stage axis;
+- configured minimum or maximum for that axis; or
+- stage-limit enablement.
+
+When the user moves the focus stage or edits/toggles limits while the popup is
+open, the warning and spinbox color will update immediately. Correcting the
+condition clears the warning and restores the normal text color.
+
+The Start Autofocus button remains governed by the existing acquisition-state
+logic. Clicking it with a bounds error performs one final controller preflight,
+shows an error dialog with the same actionable message, and does not dispatch
+autofocus. Keeping the button available preserves that explicit final
+notification rather than silently disabling the action.
+
+## Real-Time Autofocus Plot
+
+After each image's DCT entropy value is calculated, the model will publish an
+autofocus-progress event containing the accumulated position/metric data. It
+will not publish image pixels for plotting. Acquisition and metric calculation
+must not wait for the GUI.
+
+The popup controller will follow the image-display and histogram "latest value
+wins" pattern:
+
+1. Store the newest pending progress dataset.
+2. Schedule at most one Tk `after_idle` callback.
+3. Replace older pending data if another event arrives before that callback.
+4. Update a persistent Matplotlib point artist on the Tk thread.
+
+The plot will reuse the intensity histogram's blitting strategy:
+
+- detect whether the canvas supports `copy_from_bbox`, `restore_region`, and
+  `blit`;
+- mark the changing point artist as animated when blitting is supported;
+- cache the static axes background after a full draw;
+- restore the background, draw only the changing artist, and blit the axes
+  region for ordinary point updates;
+- invalidate and rebuild the cache after resize, theme/layout changes, or axis
+  limit changes; and
+- fall back to a normal nonblocking draw when blitting is unavailable.
+
+The controller will not clear the axes, recreate artists, or run
+`tight_layout()` for every measurement. X and Y limits will expand only when
+new data require it; such an expansion performs one full redraw and refreshes
+the cached background. Ordinary points inside the current limits use blitting.
+
+At autofocus completion, one full render will preserve all measured points and
+add the selected fitted curve and peak indicators. Cancellation will leave the
+partial measured curve visible rather than replacing it with nonexistent final
+data.
+
+## Event and Thread Boundaries
+
+The model data thread owns focus-metric calculation and progress publication.
+The main controller's existing event pump transfers progress to the popup
+controller. All Tk and Matplotlib artist mutation occurs on the Tk main thread.
+Progress events are snapshots and may be coalesced for display; the model's
+authoritative `plot_data` retains every measurement for fitting and final
+reporting.
+
+## Error Handling
+
+- Invalid coarse or fine-only paths are rejected before acquisition begins.
+- An invalid combined fine path is rejected after coarse analysis and before
+  the first fine move.
+- A failed stage move aborts autofocus and is never represented as a successful
+  measurement position.
+- Controller and model errors use the same scan label, requested interval, and
+  allowed interval so immediate and final feedback agree.
+- Plot-rendering failures are logged and isolated from acquisition; they do not
+  stop autofocus.
+- Unsupported blitting backends use the full-draw fallback.
+
+## Testing
+
+Phase 1 tests will cover:
+
+- exact position planning for odd and even frame counts;
+- valid paths and lower-bound, upper-bound, and both-bound violations;
+- limits enabled and disabled;
+- coarse-only, fine-only, and combined coarse-to-fine behavior;
+- rejection before acquisition preparation or the first affected move;
+- failed moves not entering the autofocus frame queue;
+- red Range spinbox and inline warning behavior;
+- warning clearance after stage movement, limit edits, or limit toggles; and
+- the final dialog and absence of autofocus dispatch for an invalid path.
+
+Phase 2 tests will cover:
+
+- one progress publication per processed autofocus measurement;
+- snapshots retaining every calculated point;
+- coalescing multiple pending updates into the newest dataset;
+- persistent artist updates without artist accumulation;
+- the blit path, cache invalidation, and non-blit fallback;
+- axis expansion causing a full redraw before blitting resumes;
+- final fit and peak overlays; and
+- cancellation preserving the partial plot.
+
+Focused model and controller tests will run after each phase. No native Tk
+windows will be opened on the active macOS desktop; GUI behavior will be
+covered by the repository's headless controller/view tests.
+
+## Reuse Analysis
+
+This design extends existing mechanisms rather than adding parallel lifecycle
+or rendering abstractions:
+
+- retain the existing Autofocus feature and event queue;
+- centralize and reuse its current step/range calculation instead of adding a
+  second scan algorithm;
+- use `ConfigurationController.get_stage_position_limits` and existing stage
+  limit state as the controller authority;
+- use `ValidatedSpinbox` error coloring and the active theme's danger color;
+- refresh from the existing stage-position and stage-limit update paths;
+- reuse the controller event pump for progress delivery; and
+- mirror `HistogramController`'s `after_idle` coalescing, persistent artist,
+  background invalidation, blitting, and fallback behavior.
+
+No new user-callable public API or independent plotting framework is required.

--- a/src/navigate/controller/autofocus_calibration.py
+++ b/src/navigate/controller/autofocus_calibration.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2021-2026  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+"""Persistent autofocus defocus-calibration event processing."""
+
+from tkinter import messagebox
+from typing import Any
+
+
+class AutofocusCalibrationController:
+    """Process autofocus completion metadata independently of popup lifetime."""
+
+    def __init__(self, parent_controller: Any) -> None:
+        """Create a calibration event processor.
+
+        Parameters
+        ----------
+        parent_controller : Any
+            Main controller that owns configuration and event listeners.
+        """
+        self.parent_controller = parent_controller
+        self.reference = None
+
+    def handle_autofocus_complete(self, payload: dict) -> None:
+        """Apply autofocus completion metadata to defocus calibration state.
+
+        Parameters
+        ----------
+        payload : dict
+            Completed autofocus channel, position, and calibration action.
+        """
+        action = payload.get("calibration_action")
+        if action == "capture_reference":
+            self.reference = {
+                "channel": payload["channel"],
+                "focus_position": float(payload["focus_position"]),
+            }
+            self._persist_reference(payload)
+            self._notify_reference()
+
+            channels = self._channels
+            reference_defocus = channels[payload["channel"]]["defocus"]
+            for channel_key in channels.keys():
+                self.write_channel_defocus(
+                    channel_key,
+                    channels[channel_key]["defocus"] - reference_defocus,
+                )
+            self._refresh_open_popup()
+            return
+
+        if action == "populate_defocus":
+            if self.reference is None:
+                messagebox.showwarning(
+                    title="Navigate",
+                    message="Capture a reference focus before populating defocus.",
+                )
+                return
+            target_channel = payload["channel"]
+            target_focus = float(payload["focus_position"])
+            focus = target_focus - self.reference["focus_position"]
+            if target_channel == self.reference["channel"]:
+                focus = 0
+            self.write_channel_defocus(target_channel, focus)
+
+        self._notify_reference()
+        self._refresh_open_popup()
+
+    @property
+    def _channels(self) -> dict:
+        """Return configured acquisition channels."""
+        return self.parent_controller.configuration["experiment"][
+            "MicroscopeState"
+        ]["channels"]
+
+    def _persist_reference(self, payload: dict) -> None:
+        """Persist reference metadata when the originating settings are known."""
+        device = payload.get("device")
+        device_ref = payload.get("device_ref")
+        if device is None or device_ref is None:
+            return
+        experiment = self.parent_controller.configuration["experiment"]
+        microscope_name = experiment["MicroscopeState"]["microscope_name"]
+        settings = experiment["AutoFocusParameters"][microscope_name][device][
+            device_ref
+        ]
+        channel = self.reference["channel"]
+        settings["reference_channel"] = (
+            f"CH{channel.removeprefix('channel_')}"
+            if channel.startswith("channel_")
+            else channel
+        )
+        settings["reference_position"] = self.reference["focus_position"]
+
+    def write_channel_defocus(self, channel_key: str, defocus: float) -> None:
+        """Write one defocus value and notify the channels controller."""
+        self._channels[channel_key]["defocus"] = defocus
+        handler = getattr(self.parent_controller, "event_listeners", {}).get(
+            "channel_defocus"
+        )
+        if handler is not None:
+            handler((channel_key, defocus))
+
+    def _notify_reference(self) -> None:
+        """Notify the channels controller of the active reference, if any."""
+        if self.reference is None:
+            return
+        handler = getattr(self.parent_controller, "event_listeners", {}).get(
+            "defocus_reference"
+        )
+        if handler is not None:
+            handler(self.reference)
+
+    def _refresh_open_popup(self) -> None:
+        """Refresh reference text only while a live popup exists."""
+        popup_controller = getattr(
+            self.parent_controller, "af_popup_controller", None
+        )
+        if popup_controller is not None:
+            popup_controller._update_reference_status()

--- a/src/navigate/controller/controller.py
+++ b/src/navigate/controller/controller.py
@@ -50,6 +50,7 @@ from navigate.view.theme import apply_theme
 
 # Local Sub-Controller Imports
 from navigate.controller.configuration_controller import ConfigurationController
+from navigate.controller.autofocus_calibration import AutofocusCalibrationController
 from navigate.controller.sub_controllers import (
     KeystrokeController,
     WaveformTabController,
@@ -199,6 +200,9 @@ class Controller:
         #: mp.Queue: Queue for retrieving events ('event_name', value) from model
         self.event_queue = mp.Queue(100)
 
+        #: mp.Queue: Single-slot, latest-value transport for autofocus plotting.
+        self.autofocus_progress_queue = mp.Queue(1)
+
         #: Manager: A shared memory manager
         self.manager = Manager()
 
@@ -235,6 +239,7 @@ class Controller:
                 args,
                 self.configuration,
                 event_queue=self.event_queue,
+                autofocus_progress_queue=self.autofocus_progress_queue,
                 log_queue=log_queue,
             )
         else:
@@ -243,6 +248,7 @@ class Controller:
                 args,
                 self.configuration,
                 event_queue=self.event_queue,
+                autofocus_progress_queue=self.autofocus_progress_queue,
                 log_queue=log_queue,
             )
 
@@ -267,8 +273,13 @@ class Controller:
         #: View: View object in MVC architecture.
         self.view = view(self.root)
 
+        #: AutofocusCalibrationController: Popup-independent calibration state.
+        self.autofocus_calibration_controller = AutofocusCalibrationController(self)
+
         #: dict: Event listeners for the controller.
-        self.event_listeners = {}
+        self.event_listeners = {
+            "autofocus_complete": self.autofocus_calibration_controller.handle_autofocus_complete
+        }
 
         #: AcquireBarController: Acquire Bar Sub-Controller.
         self.acquire_bar_controller = AcquireBarController(self.view.acquire_bar, self)
@@ -1924,6 +1935,23 @@ class Controller:
         -------
         None
         """
+        latest_progress = None
+        while self._event_pump_running:
+            try:
+                latest_progress = self.autofocus_progress_queue.get_nowait()
+            except queue.Empty:
+                break
+        if latest_progress is not None:
+            handler = self.event_listeners.get("autofocus_progress")
+            if handler is not None:
+                try:
+                    handler(latest_progress)
+                except Exception:
+                    print(
+                        "*** unhandled event: autofocus_progress, "
+                        f"{latest_progress}"
+                    )
+
         while self._event_pump_running:
             try:
                 event, value = self.event_queue.get_nowait()

--- a/src/navigate/controller/controller.py
+++ b/src/navigate/controller/controller.py
@@ -1142,6 +1142,7 @@ class Controller:
             if microscope_name == self.configuration_controller.microscope_name:
                 self.stage_controller.initialize()
                 self.channels_tab_controller.update_stack_position_limits()
+                self._refresh_autofocus_bounds()
             self.threads_pool.createThread(
                 resourceName="model",
                 target=self.update_stage_limits,
@@ -1265,7 +1266,9 @@ class Controller:
 
         elif command == "stage_limits":
             self.stage_controller.stage_limits = args[0]
+            self.configuration["experiment"]["StageParameters"]["limits"] = args[0]
             self.channels_tab_controller.update_stack_position_limits()
+            self._refresh_autofocus_bounds()
             self.threads_pool.createThread(
                 resourceName="model",
                 target=lambda: self.model.run_command("stage_limits", *args),
@@ -1876,6 +1879,13 @@ class Controller:
             ax = axis.split("_")[0]
             stage_gui_dict[ax] = val
         self.stage_controller.set_position_silent(stage_gui_dict)
+        self._refresh_autofocus_bounds()
+
+    def _refresh_autofocus_bounds(self) -> None:
+        """Refresh an open autofocus popup after stage state changes."""
+        autofocus_controller = getattr(self, "af_popup_controller", None)
+        if autofocus_controller is not None:
+            autofocus_controller.refresh_bounds_validation()
 
     def update_frame_rate(self, frame_rate: float) -> None:
         """Update the frame rate display in the GUI.

--- a/src/navigate/controller/sub_controllers/autofocus.py
+++ b/src/navigate/controller/sub_controllers/autofocus.py
@@ -82,9 +82,9 @@ class AutofocusPopupController(GUIController):
         if calibration_controller is None:
             calibration_controller = AutofocusCalibrationController(parent_controller)
             parent_controller.autofocus_calibration_controller = calibration_controller
-        parent_controller.event_listeners[
-            "autofocus_complete"
-        ] = calibration_controller.handle_autofocus_complete
+        parent_controller.event_listeners["autofocus_complete"] = (
+            calibration_controller.handle_autofocus_complete
+        )
         self.calibration_controller = calibration_controller
 
         super().__init__(view, parent_controller)
@@ -157,9 +157,11 @@ class AutofocusPopupController(GUIController):
         self.acquisition_state = getattr(
             self.parent_controller,
             "autofocus_acquisition_state",
-            "running"
-            if acquire_bar_controller and acquire_bar_controller.is_acquiring
-            else "idle",
+            (
+                "running"
+                if acquire_bar_controller and acquire_bar_controller.is_acquiring
+                else "idle"
+            ),
         )
         self.autofocus_active = bool(
             getattr(self.parent_controller, "is_autofocusing", False)
@@ -318,8 +320,10 @@ class AutofocusPopupController(GUIController):
         # verify autofocus parameters
         setting_dict = self.setting_dict[self.microscope_name][device][device_ref]
         warning_message = ""
+        is_selected = False
         for k in ["coarse", "fine"]:
             if setting_dict[f"{k}_selected"]:
+                is_selected = True
                 try:
                     step = float(setting_dict[f"{k}_step_size"])
                     value = float(setting_dict[f"{k}_range"])
@@ -328,6 +332,8 @@ class AutofocusPopupController(GUIController):
                 except Exception as e:
                     logger.exception(e)
                     warning_message += f"{k} settings are not correct!\n"
+        if not is_selected:
+            warning_message = "Please select at least one mode: Coarse or Fine."
         if warning_message:
             messagebox.showerror(
                 title="Navigate",
@@ -480,9 +486,9 @@ class AutofocusPopupController(GUIController):
         def func(*_: tuple[str]) -> None:
             device = self.widgets["device"].widget.get()
             device_ref = self.widgets["device_ref"].widget.get()
-            self.setting_dict[self.microscope_name][device][device_ref][
-                parameter
-            ] = self.view.setting_vars[parameter].get()
+            self.setting_dict[self.microscope_name][device][device_ref][parameter] = (
+                self.view.setting_vars[parameter].get()
+            )
             self.refresh_bounds_validation()
 
         return func
@@ -509,10 +515,14 @@ class AutofocusPopupController(GUIController):
                     center = float(stage_parameters[device_ref])
                     minimum = self.parent_controller.configuration_controller.get_stage_position_limits(
                         "_min"
-                    )[device_ref]
+                    )[
+                        device_ref
+                    ]
                     maximum = self.parent_controller.configuration_controller.get_stage_position_limits(
                         "_max"
-                    )[device_ref]
+                    )[
+                        device_ref
+                    ]
                     settings = self.setting_dict[self.microscope_name][device][
                         device_ref
                     ]
@@ -600,9 +610,7 @@ class AutofocusPopupController(GUIController):
         self.autofocus_coarse.clear()
         self.autofocus_coarse.set_title("Discrete Cosine Transform", fontsize=18)
         self.autofocus_coarse.set_xlabel("Focus Stage Position", fontsize=16)
-        self.autofocus_coarse.ticklabel_format(
-            style="sci", axis="y", scilimits=(0, 0)
-        )
+        self.autofocus_coarse.ticklabel_format(style="sci", axis="y", scilimits=(0, 0))
         self.autofocus_coarse.yaxis.set_minor_locator(tck.AutoMinorLocator())
         self.autofocus_coarse.xaxis.set_minor_locator(tck.AutoMinorLocator())
         self._autofocus_artist = self.autofocus_coarse.plot(
@@ -732,10 +740,8 @@ class AutofocusPopupController(GUIController):
             return
         if event is None or getattr(event, "canvas", None) is self.autofocus_fig.canvas:
             try:
-                self._autofocus_background = (
-                    self.autofocus_fig.canvas.copy_from_bbox(
-                        self.autofocus_coarse.bbox
-                    )
+                self._autofocus_background = self.autofocus_fig.canvas.copy_from_bbox(
+                    self.autofocus_coarse.bbox
                 )
             except Exception:
                 self._autofocus_background = None

--- a/src/navigate/controller/sub_controllers/autofocus.py
+++ b/src/navigate/controller/sub_controllers/autofocus.py
@@ -32,6 +32,7 @@
 
 # Standard Library Imports
 import logging
+import threading
 
 # Third Party Imports
 import numpy as np
@@ -98,6 +99,42 @@ class AutofocusPopupController(GUIController):
         #: object: The autofocus coarse plot.
         self.coarse_plot = None
 
+        #: int: Thread identifier used to keep plot mutations on the Tk thread.
+        self._main_thread_ident = threading.get_ident()
+
+        #: np.ndarray: Latest autofocus progress snapshot waiting to be rendered.
+        self._pending_autofocus_data = None
+
+        #: str: Tk after-id for the coalesced autofocus progress callback.
+        self._autofocus_after_id = None
+
+        canvas = self.autofocus_fig.canvas
+
+        #: bool: Whether the active Matplotlib canvas supports artist blitting.
+        self._blit_supported = all(
+            hasattr(canvas, method)
+            for method in ("copy_from_bbox", "restore_region", "blit")
+        )
+
+        #: object: Cached static axes background for autofocus blitting.
+        self._autofocus_background = None
+
+        #: object: Persistent artist containing measured autofocus points.
+        self._autofocus_artist = None
+
+        #: bool: Whether the next update requires a full canvas draw.
+        self._force_full_redraw = True
+
+        #: bool: Whether the most recent progress render used blitting.
+        self._last_render_used_blit = False
+
+        #: tuple: Last live x/y axis bounds.
+        self._last_xlim = None
+        self._last_ylim = None
+
+        canvas.mpl_connect("draw_event", self._on_autofocus_draw)
+        canvas.mpl_connect("resize_event", self._invalidate_autofocus_blit_cache)
+
         # Dismiss popup.
         self.view.popup.protocol("WM_DELETE_WINDOW", self.close_popup)
         self.view.popup.bind("<Escape>", self.close_popup)
@@ -152,6 +189,7 @@ class AutofocusPopupController(GUIController):
         """
         # We should add saving function to the function closing the window
 
+        self._cancel_pending_autofocus_update()
         self.view.popup.dismiss()
         delattr(self.parent_controller, "af_popup_controller")
 
@@ -335,6 +373,7 @@ class AutofocusPopupController(GUIController):
             reference_channel = self.defocus_calibration_reference["channel"]
 
         self._write_channel_defocus(target_channel, 0)
+        self._initialize_progress_plot()
         self.parent_controller.execute(
             "autofocus",
             device,
@@ -540,6 +579,194 @@ class AutofocusPopupController(GUIController):
         self.view.bounds_warning_var.set("\n".join(errors))
         return errors
 
+    def display_autofocus_progress(self, data) -> None:
+        """Queue the latest autofocus measurements for a Tk-thread update."""
+        if threading.get_ident() != self._main_thread_ident:
+            run_on_main = getattr(self.parent_controller, "_run_on_main_thread", None)
+            if callable(run_on_main):
+                run_on_main(self.display_autofocus_progress, data, wait=False)
+            return
+
+        progress_data = np.asarray(data, dtype=float)
+        self._pending_autofocus_data = progress_data.copy()
+        if self._autofocus_after_id is not None:
+            return
+
+        widget = self.autofocus_fig.canvas.get_tk_widget()
+        self._autofocus_after_id = widget.after_idle(
+            self._flush_pending_autofocus_update
+        )
+
+    def _flush_pending_autofocus_update(self) -> None:
+        """Render only the newest pending autofocus progress snapshot."""
+        self._autofocus_after_id = None
+        data = self._pending_autofocus_data
+        self._pending_autofocus_data = None
+        if data is None:
+            return
+        try:
+            self._update_progress_plot(data)
+        except Exception as exc:
+            logger.exception("Autofocus plot update failed: %s", exc)
+
+    def _cancel_pending_autofocus_update(self) -> None:
+        """Cancel a scheduled progress update without changing plotted data."""
+        if self._autofocus_after_id is not None:
+            try:
+                self.autofocus_fig.canvas.get_tk_widget().after_cancel(
+                    self._autofocus_after_id
+                )
+            except Exception:
+                pass
+        self._autofocus_after_id = None
+        self._pending_autofocus_data = None
+
+    def _initialize_progress_plot(self) -> None:
+        """Prepare static axes and one persistent measured-points artist."""
+        self._cancel_pending_autofocus_update()
+        self.autofocus_coarse.clear()
+        self.autofocus_coarse.set_title("Discrete Cosine Transform", fontsize=18)
+        self.autofocus_coarse.set_xlabel("Focus Stage Position", fontsize=16)
+        self.autofocus_coarse.ticklabel_format(
+            style="sci", axis="y", scilimits=(0, 0)
+        )
+        self.autofocus_coarse.yaxis.set_minor_locator(tck.AutoMinorLocator())
+        self.autofocus_coarse.xaxis.set_minor_locator(tck.AutoMinorLocator())
+        self._autofocus_artist = self.autofocus_coarse.plot(
+            [], [], "k.", animated=self._blit_supported
+        )[0]
+        self._last_xlim = self._get_initial_progress_xlim()
+        if self._last_xlim is not None:
+            self.autofocus_coarse.set_xlim(*self._last_xlim)
+        self._last_ylim = None
+        self._invalidate_autofocus_blit_cache()
+        self.autofocus_fig.tight_layout()
+        self._render_autofocus(force_full_redraw=True)
+
+    def _get_initial_progress_xlim(self):
+        """Return padded x limits for the exact immediately knowable scan."""
+        try:
+            device = self.widgets["device"].widget.get()
+            device_ref = self.widgets["device_ref"].widget.get()
+            settings = self.setting_dict[self.microscope_name][device][device_ref]
+            if settings["coarse_selected"]:
+                scan_name = "coarse"
+            elif settings["fine_selected"]:
+                scan_name = "fine"
+            else:
+                return None
+            center = 0.0
+            if device == "stage":
+                center = float(
+                    self.parent_controller.configuration["experiment"][
+                        "StageParameters"
+                    ][device_ref]
+                )
+            positions = plan_autofocus_positions(
+                center,
+                float(settings[f"{scan_name}_range"]),
+                float(settings[f"{scan_name}_step_size"]),
+            )
+            limits, _ = self._expanded_limits(None, positions)
+            return limits
+        except (KeyError, TypeError, ValueError, ZeroDivisionError):
+            return None
+
+    @staticmethod
+    def _expanded_limits(current, values):
+        """Return live axis limits that expand, but never shrink, as data arrive."""
+        finite_values = np.asarray(values, dtype=float)
+        finite_values = finite_values[np.isfinite(finite_values)]
+        if finite_values.size == 0:
+            return current, False
+
+        data_minimum = float(np.min(finite_values))
+        data_maximum = float(np.max(finite_values))
+        span = data_maximum - data_minimum
+        if span > 0:
+            padding = span * 0.1
+        else:
+            padding = max(abs(data_minimum) * 0.1, 1e-9)
+        target = (data_minimum - padding, data_maximum + padding)
+        if current is None:
+            return target, True
+        if data_minimum >= current[0] and data_maximum <= current[1]:
+            return current, False
+        return (min(current[0], target[0]), max(current[1], target[1])), True
+
+    def _update_progress_plot(self, data: np.ndarray) -> None:
+        """Update the persistent measured-points artist from one snapshot."""
+        data = np.asarray(data, dtype=float)
+        if data.size == 0:
+            return
+        if data.ndim != 2 or data.shape[1] < 2:
+            raise ValueError("Autofocus progress data must have two columns.")
+        if self._autofocus_artist is None:
+            self._initialize_progress_plot()
+
+        self._autofocus_artist.set_data(data[:, 0], data[:, 1])
+        force_full_redraw = self._force_full_redraw
+
+        x_limits, x_changed = self._expanded_limits(self._last_xlim, data[:, 0])
+        if x_changed:
+            self.autofocus_coarse.set_xlim(*x_limits)
+            self._last_xlim = x_limits
+            force_full_redraw = True
+
+        y_limits, y_changed = self._expanded_limits(self._last_ylim, data[:, 1])
+        if y_changed:
+            self.autofocus_coarse.set_ylim(*y_limits)
+            self._last_ylim = y_limits
+            force_full_redraw = True
+
+        self._render_autofocus(force_full_redraw=force_full_redraw)
+
+    def _render_autofocus(self, force_full_redraw: bool = False) -> None:
+        """Render live autofocus points with blitting or a full-draw fallback."""
+        canvas = self.autofocus_fig.canvas
+        can_blit = self._blit_supported and self._autofocus_artist is not None
+        if (
+            not can_blit
+            or force_full_redraw
+            or self._autofocus_background is None
+            or self._force_full_redraw
+        ):
+            canvas.draw()
+            self._last_render_used_blit = False
+            self._force_full_redraw = False
+            if can_blit:
+                self._autofocus_background = canvas.copy_from_bbox(
+                    self.autofocus_coarse.bbox
+                )
+                canvas.restore_region(self._autofocus_background)
+                self.autofocus_coarse.draw_artist(self._autofocus_artist)
+                canvas.blit(self.autofocus_coarse.bbox)
+            return
+
+        canvas.restore_region(self._autofocus_background)
+        self.autofocus_coarse.draw_artist(self._autofocus_artist)
+        canvas.blit(self.autofocus_coarse.bbox)
+        self._last_render_used_blit = True
+
+    def _invalidate_autofocus_blit_cache(self, *_args) -> None:
+        """Clear the background cache so the next update performs a full draw."""
+        self._autofocus_background = None
+        self._force_full_redraw = True
+
+    def _on_autofocus_draw(self, event) -> None:
+        """Refresh the static background cache after a full canvas draw."""
+        if not self._blit_supported:
+            return
+        if event is None or getattr(event, "canvas", None) is self.autofocus_fig.canvas:
+            try:
+                self._autofocus_background = (
+                    self.autofocus_fig.canvas.copy_from_bbox(
+                        self.autofocus_coarse.bbox
+                    )
+                )
+            except Exception:
+                self._autofocus_background = None
+
     def display_plot(self, data_and_flags: tuple[np.ndarray, bool, bool]) -> None:
         """
         Display autofocus data, handling segmentation, plot mode, and redraw.
@@ -579,6 +806,11 @@ class AutofocusPopupController(GUIController):
         coarse_steps = int(coarse_range) // int(coarse_step) + 1
 
         if clear_data:
+            self._cancel_pending_autofocus_update()
+            self._autofocus_artist = None
+            self._invalidate_autofocus_blit_cache()
+            self._last_xlim = None
+            self._last_ylim = None
             self.autofocus_coarse.clear()
             if data.shape[0] > 0:
                 self.autofocus_coarse.plot(
@@ -664,5 +896,6 @@ class AutofocusPopupController(GUIController):
         """
         return {
             "autofocus": self.display_plot,
+            "autofocus_progress": self.display_autofocus_progress,
             "autofocus_complete": self.handle_autofocus_complete,
         }

--- a/src/navigate/controller/sub_controllers/autofocus.py
+++ b/src/navigate/controller/sub_controllers/autofocus.py
@@ -41,6 +41,8 @@ from tkinter import messagebox
 # Local Imports
 import navigate
 from navigate.controller.sub_controllers.gui import GUIController
+from navigate.model.features.autofocus import autofocus_bounds_error
+from navigate.model.features.autofocus import plan_autofocus_positions
 from navigate.view.popups.autofocus_setting_popup import AutofocusPopup
 
 # Logger Setup
@@ -124,6 +126,7 @@ class AutofocusPopupController(GUIController):
         )
         for k in self.view.setting_vars:
             self.view.setting_vars[k].trace_add("write", self.update_setting_dict(k))
+        self.refresh_bounds_validation()
 
     @staticmethod
     def _channel_key_to_label(channel_key: str) -> str:
@@ -276,6 +279,13 @@ class AutofocusPopupController(GUIController):
             messagebox.showerror(
                 title="Navigate",
                 message=warning_message,
+            )
+            return
+        bounds_errors = self.refresh_bounds_validation()
+        if bounds_errors:
+            messagebox.showerror(
+                title="Navigate",
+                message="\n".join(bounds_errors),
             )
             return
         target_channel = self._channel_label_to_key(
@@ -439,6 +449,7 @@ class AutofocusPopupController(GUIController):
         setting_dict = self.setting_dict[self.microscope_name]
         for k in self.view.setting_vars:
             self.view.setting_vars[k].set(setting_dict[device][device_ref][k])
+        self.refresh_bounds_validation()
 
     def update_setting_dict(self, parameter: str) -> callable:
         """Show Autofocus Parameters
@@ -460,8 +471,74 @@ class AutofocusPopupController(GUIController):
             self.setting_dict[self.microscope_name][device][device_ref][
                 parameter
             ] = self.view.setting_vars[parameter].get()
+            self.refresh_bounds_validation()
 
         return func
+
+    def refresh_bounds_validation(self) -> list[str]:
+        """Refresh advisory scan bounds feedback from current stage state.
+
+        Returns
+        -------
+        list[str]
+            Immediately knowable bounds diagnostics.
+        """
+        errors = []
+        scan_errors = {"coarse": False, "fine": False}
+        device = self.widgets["device"].widget.get()
+        device_ref = self.widgets["device_ref"].widget.get()
+
+        if device == "stage":
+            stage_parameters = self.parent_controller.configuration["experiment"][
+                "StageParameters"
+            ]
+            if stage_parameters.get("limits", True):
+                try:
+                    center = float(stage_parameters[device_ref])
+                    minimum = self.parent_controller.configuration_controller.get_stage_position_limits(
+                        "_min"
+                    )[device_ref]
+                    maximum = self.parent_controller.configuration_controller.get_stage_position_limits(
+                        "_max"
+                    )[device_ref]
+                    settings = self.setting_dict[self.microscope_name][device][
+                        device_ref
+                    ]
+
+                    scans_to_validate = []
+                    if settings["coarse_selected"]:
+                        scans_to_validate.append("coarse")
+                    elif settings["fine_selected"]:
+                        scans_to_validate.append("fine")
+
+                    for scan_name in scans_to_validate:
+                        scan_range = float(settings[f"{scan_name}_range"])
+                        step_size = float(settings[f"{scan_name}_step_size"])
+                        if step_size <= 0 or scan_range < step_size:
+                            continue
+                        positions = plan_autofocus_positions(
+                            center, scan_range, step_size
+                        )
+                        error = autofocus_bounds_error(
+                            scan_name,
+                            positions,
+                            minimum,
+                            maximum,
+                            device_ref,
+                        )
+                        if error:
+                            errors.append(error)
+                            scan_errors[scan_name] = True
+                except (KeyError, TypeError, ValueError):
+                    pass
+
+        for scan_name in ("coarse", "fine"):
+            range_widget = self.widgets[f"{scan_name}_range"].widget
+            range_widget._toggle_error(
+                scan_errors[scan_name] or bool(range_widget.error.get())
+            )
+        self.view.bounds_warning_var.set("\n".join(errors))
+        return errors
 
     def display_plot(self, data_and_flags: tuple[np.ndarray, bool, bool]) -> None:
         """

--- a/src/navigate/controller/sub_controllers/autofocus.py
+++ b/src/navigate/controller/sub_controllers/autofocus.py
@@ -190,8 +190,13 @@ class AutofocusPopupController(GUIController):
         # We should add saving function to the function closing the window
 
         self._cancel_pending_autofocus_update()
+        event_listeners = getattr(self.parent_controller, "event_listeners", {})
+        for event_name, event_handler in self.custom_events.items():
+            if event_listeners.get(event_name) == event_handler:
+                event_listeners.pop(event_name)
         self.view.popup.dismiss()
-        delattr(self.parent_controller, "af_popup_controller")
+        if getattr(self.parent_controller, "af_popup_controller", None) is self:
+            delattr(self.parent_controller, "af_popup_controller")
 
     def populate_experiment_values(self) -> None:
         """Populate Experiment Values

--- a/src/navigate/controller/sub_controllers/autofocus.py
+++ b/src/navigate/controller/sub_controllers/autofocus.py
@@ -33,6 +33,7 @@
 # Standard Library Imports
 import logging
 import threading
+from typing import Optional
 
 # Third Party Imports
 import numpy as np
@@ -42,6 +43,7 @@ from tkinter import messagebox
 # Local Imports
 import navigate
 from navigate.controller.sub_controllers.gui import GUIController
+from navigate.controller.autofocus_calibration import AutofocusCalibrationController
 from navigate.model.features.autofocus import autofocus_bounds_error
 from navigate.model.features.autofocus import plan_autofocus_positions
 from navigate.view.popups.autofocus_setting_popup import AutofocusPopup
@@ -74,6 +76,17 @@ class AutofocusPopupController(GUIController):
         parent_controller : navigate.controller.controller.Controller
             The parent controller of the autofocus popup.
         """
+        calibration_controller = getattr(
+            parent_controller, "autofocus_calibration_controller", None
+        )
+        if calibration_controller is None:
+            calibration_controller = AutofocusCalibrationController(parent_controller)
+            parent_controller.autofocus_calibration_controller = calibration_controller
+        parent_controller.event_listeners[
+            "autofocus_complete"
+        ] = calibration_controller.handle_autofocus_complete
+        self.calibration_controller = calibration_controller
+
         super().__init__(view, parent_controller)
 
         #: dict: The autofocus setting dictionary.
@@ -90,9 +103,6 @@ class AutofocusPopupController(GUIController):
 
         #: object: The autofocus coarse plot.
         self.autofocus_coarse = self.view.coarse
-
-        #: dict: Temporary reference focus for defocus calibration.
-        self.defocus_calibration_reference = None
 
         self.populate_experiment_values()
 
@@ -391,57 +401,21 @@ class AutofocusPopupController(GUIController):
 
     def handle_autofocus_complete(self, payload: dict) -> None:
         """Handle autofocus completion metadata for defocus calibration."""
-        action = payload.get("calibration_action")
-        if action == "capture_reference":
-            self.defocus_calibration_reference = {
-                "channel": payload["channel"],
-                "focus_position": float(payload["focus_position"]),
-            }
-            self._update_reference_status()
-            self._notify_defocus_reference(self.defocus_calibration_reference)
-            # update defocus value
-            channels = self.parent_controller.configuration["experiment"][
-                "MicroscopeState"
-            ]["channels"]
-            defocus = channels[payload["channel"]]["defocus"]
-            for channel_key in channels.keys():
-                self._write_channel_defocus(
-                    channel_key, channels[channel_key]["defocus"] - defocus
-                )
-            return
-
-        if action == "populate_defocus":
-            if self.defocus_calibration_reference is None:
-                self._show_missing_reference_warning()
-                return
-            target_channel = payload["channel"]
-            target_focus = float(payload["focus_position"])
-            reference_focus = self.defocus_calibration_reference["focus_position"]
-            focus = target_focus - reference_focus
-            if target_channel == self.defocus_calibration_reference["channel"]:
-                focus = 0
-            self._write_channel_defocus(target_channel, focus)
-
-        if self.defocus_calibration_reference is not None:
-            self._notify_defocus_reference(self.defocus_calibration_reference)
+        self.calibration_controller.handle_autofocus_complete(payload)
 
     def _write_channel_defocus(self, channel_key: str, defocus: float) -> None:
-        channels = self.parent_controller.configuration["experiment"][
-            "MicroscopeState"
-        ]["channels"]
-        channels[channel_key]["defocus"] = defocus
-        handler = getattr(self.parent_controller, "event_listeners", {}).get(
-            "channel_defocus"
-        )
-        if handler is not None:
-            handler((channel_key, defocus))
+        """Write a defocus value through the persistent calibration state."""
+        self.calibration_controller.write_channel_defocus(channel_key, defocus)
 
-    def _notify_defocus_reference(self, reference: dict) -> None:
-        handler = getattr(self.parent_controller, "event_listeners", {}).get(
-            "defocus_reference"
-        )
-        if handler is not None:
-            handler(reference)
+    @property
+    def defocus_calibration_reference(self) -> Optional[dict]:
+        """Return popup-independent defocus calibration reference state."""
+        return self.calibration_controller.reference
+
+    @defocus_calibration_reference.setter
+    def defocus_calibration_reference(self, reference: Optional[dict]) -> None:
+        """Set popup-independent defocus calibration reference state."""
+        self.calibration_controller.reference = reference
 
     def _update_reference_status(self) -> None:
         if not hasattr(self.view, "reference_status_var"):
@@ -460,12 +434,6 @@ class AutofocusPopupController(GUIController):
         # update reference channel info in the experiment file
         self.setting_dict["reference_channel"] = channel
         self.setting_dict["reference_position"] = focus
-
-    def _show_missing_reference_warning(self) -> None:
-        messagebox.showwarning(
-            title="Navigate",
-            message="Capture a reference focus before populating defocus.",
-        )
 
     def update_device_ref(self, *_: tuple[str]) -> None:
         """Update device reference name
@@ -902,5 +870,4 @@ class AutofocusPopupController(GUIController):
         return {
             "autofocus": self.display_plot,
             "autofocus_progress": self.display_autofocus_progress,
-            "autofocus_complete": self.handle_autofocus_complete,
         }

--- a/src/navigate/controller/sub_controllers/stages_advanced.py
+++ b/src/navigate/controller/sub_controllers/stages_advanced.py
@@ -30,7 +30,7 @@
 
 # Standard Library Imports
 import logging
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 # Third Party Imports
 
@@ -39,6 +39,9 @@ from navigate.config.config import update_config_dict
 from navigate.tools.file_functions import write_to_yaml
 from navigate.view.popups.stages_advanced_popup import AdvancedStageParametersPopup
 from navigate.controller.configuration_controller import ConfigurationController
+
+if TYPE_CHECKING:
+    from navigate.controller.controller import Controller
 
 # Logger Setup
 p = __name__.split(".")[1]
@@ -302,6 +305,20 @@ class AdvancedStageParametersController:
 
         # Update our local stage dictionary with the new value.
         self.stage_dict[axis] = value
+        shared_stage_dict = self.parent_controller.configuration["configuration"][
+            "microscopes"
+        ][self.current_microscope]["stage"]
+        shared_stage_dict[axis] = value
+        if (
+            axis.endswith(("_min", "_max"))
+            and self.current_microscope
+            == self.parent_controller.configuration_controller.microscope_name
+        ):
+            refresh_bounds = getattr(
+                self.parent_controller, "_refresh_autofocus_bounds", None
+            )
+            if callable(refresh_bounds):
+                refresh_bounds()
         logger.debug(
             f"Updating {axis} limit to {value} for {self.current_microscope}..."
         )

--- a/src/navigate/model/features/autofocus.py
+++ b/src/navigate/model/features/autofocus.py
@@ -31,7 +31,7 @@
 
 
 # Standard Library Imports
-from queue import Empty, Queue
+from queue import Empty, Full, Queue
 import threading
 
 # Third Party Imports
@@ -70,7 +70,10 @@ def plan_autofocus_positions(center, scan_range, step_size):
 
 def _format_position(position):
     """Format a stage position without obscuring a bounds violation."""
-    return f"{float(position):g}"
+    value = repr(float(position))
+    if "e" not in value.lower() and value.endswith(".0"):
+        return value[:-2]
+    return value
 
 
 def autofocus_bounds_error(scan_name, positions, minimum, maximum, device_ref):
@@ -158,6 +161,7 @@ class Autofocus:
         calibration_action=None,
         reference_channel=None,
         set_defocus_for_all_flag=False,
+        scan_settings=None,
     ):
         """Initialize the Autofocus class.
 
@@ -265,6 +269,11 @@ class Autofocus:
         #: str: Device reference
         self.device_ref = device_ref
 
+        #: bool: Whether scan settings have been frozen for this acquisition.
+        self._scan_settings_frozen = False
+        if scan_settings is not None:
+            self._apply_scan_settings(scan_settings)
+
     def run(self):
         """Run the Autofocusing Routine
 
@@ -301,6 +310,8 @@ class Autofocus:
                 self.target_channel,
                 self.calibration_action,
                 self.reference_channel,
+                self.set_defocus_for_all_flag,
+                self._get_frozen_scan_settings(),
             ),
         }
 
@@ -322,6 +333,8 @@ class Autofocus:
                                 channel_key,
                                 "populate_defocus",
                                 self.reference_channel,
+                                False,
+                                self._get_frozen_scan_settings(),
                             ),
                         }
                     )
@@ -353,27 +366,56 @@ class Autofocus:
         int
             Number of frames to be processed.
         """
-        settings = self.model.configuration["experiment"]["AutoFocusParameters"][
-            self.model.active_microscope_name
-        ][self.device][self.device_ref]
+        self._freeze_scan_settings()
         frames = 0
-        if settings["coarse_selected"]:
+        if self.coarse_selected:
             frames = len(
                 plan_autofocus_positions(
                     0,
-                    float(settings["coarse_range"]),
-                    float(settings["coarse_step_size"]),
+                    self.coarse_range,
+                    self.coarse_step_size,
                 )
             )
-        if settings["fine_selected"]:
+        if self.fine_selected:
             frames += len(
                 plan_autofocus_positions(
                     0,
-                    float(settings["fine_range"]),
-                    float(settings["fine_step_size"]),
+                    self.fine_range,
+                    self.fine_step_size,
                 )
             )
         return frames
+
+    def _freeze_scan_settings(self):
+        """Snapshot motion-defining settings for one autofocus acquisition."""
+        if self._scan_settings_frozen:
+            return
+        settings = self.model.configuration["experiment"]["AutoFocusParameters"][
+            self.model.active_microscope_name
+        ][self.device][self.device_ref]
+        self._apply_scan_settings(settings)
+
+    def _apply_scan_settings(self, settings):
+        """Apply a motion-settings snapshot to this autofocus instance."""
+        self.coarse_selected = bool(settings["coarse_selected"])
+        self.coarse_range = float(settings["coarse_range"])
+        self.coarse_step_size = float(settings["coarse_step_size"])
+        self.fine_selected = bool(settings["fine_selected"])
+        self.fine_range = float(settings["fine_range"])
+        self.fine_step_size = float(settings["fine_step_size"])
+        self._scan_settings_frozen = True
+
+    def _get_frozen_scan_settings(self):
+        """Return a serializable copy of the frozen motion settings."""
+        self._freeze_scan_settings()
+        return {
+            "coarse_selected": self.coarse_selected,
+            "coarse_range": self.coarse_range,
+            "coarse_step_size": self.coarse_step_size,
+            "fine_selected": self.fine_selected,
+            "fine_range": self.fine_range,
+            "fine_step_size": self.fine_step_size,
+        }
 
     def _stage_scan_bounds_error(self, scan_name, positions):
         """Return a stage-bounds diagnostic for an exact scan trajectory."""
@@ -394,26 +436,24 @@ class Autofocus:
         """Validate the scan whose center is knowable before acquisition."""
         if self.device != "stage":
             return None
-        settings = self.model.configuration["experiment"]["AutoFocusParameters"][
-            self.model.active_microscope_name
-        ][self.device][self.device_ref]
+        self._freeze_scan_settings()
         center = float(
             self.model.configuration["experiment"]["StageParameters"][
                 self.device_ref
             ]
         )
-        if settings["coarse_selected"]:
+        if self.coarse_selected:
             positions = plan_autofocus_positions(
                 center,
-                float(settings["coarse_range"]),
-                float(settings["coarse_step_size"]),
+                self.coarse_range,
+                self.coarse_step_size,
             )
             return self._stage_scan_bounds_error("coarse", positions)
-        if settings["fine_selected"]:
+        if self.fine_selected:
             positions = plan_autofocus_positions(
                 center,
-                float(settings["fine_range"]),
-                float(settings["fine_step_size"]),
+                self.fine_range,
+                self.fine_step_size,
             )
             return self._stage_scan_bounds_error("fine", positions)
         return None
@@ -467,10 +507,7 @@ class Autofocus:
     def pre_func_signal(self):
         """Prepare the autofocus routine."""
         self.prepare_selected_channel()
-
-        settings = self.model.configuration["experiment"]["AutoFocusParameters"][
-            self.model.active_microscope_name
-        ][self.device][self.device_ref]
+        self._freeze_scan_settings()
         if self.device == "stage":
             self.focus_pos = self.model.configuration["experiment"]["StageParameters"][
                 self.device_ref
@@ -482,20 +519,18 @@ class Autofocus:
         self.coarse_positions = ()
         self.fine_positions = ()
 
-        if settings["fine_selected"]:
-            self.fine_step_size = float(settings["fine_step_size"])
+        if self.fine_selected:
             self.fine_positions = plan_autofocus_positions(
                 self.focus_pos,
-                float(settings["fine_range"]),
+                self.fine_range,
                 self.fine_step_size,
             )
             self.init_pos = self.fine_positions[0] - self.fine_step_size
 
-        if settings["coarse_selected"]:
-            self.coarse_step_size = float(settings["coarse_step_size"])
+        if self.coarse_selected:
             self.coarse_positions = plan_autofocus_positions(
                 self.focus_pos,
-                float(settings["coarse_range"]),
+                self.coarse_range,
                 self.coarse_step_size,
             )
             self.coarse_steps = len(self.coarse_positions)
@@ -545,12 +580,9 @@ class Autofocus:
                 focus_position = self._wait_for_focus_position()
                 if focus_position is None:
                     return None
-                settings = self.model.configuration["experiment"][
-                    "AutoFocusParameters"
-                ][self.model.active_microscope_name][self.device][self.device_ref]
                 self.fine_positions = plan_autofocus_positions(
                     focus_position,
-                    float(settings["fine_range"]),
+                    self.fine_range,
                     self.fine_step_size,
                 )
                 bounds_error = self._stage_scan_bounds_error(
@@ -655,7 +687,15 @@ class Autofocus:
                 [float(position), float(metric)]
                 for position, metric in self.plot_data
             ]
-            self.model.event_queue.put(("autofocus_progress", progress_snapshot))
+            try:
+                self.model.event_queue.put_nowait(
+                    ("autofocus_progress", progress_snapshot)
+                )
+            except Full:
+                self.model.logger.debug(
+                    "Dropping autofocus progress snapshot because the event queue "
+                    "is full."
+                )
             # Need to initialize entropy above for the first iteration of the autofocus
             # routine. Need to initialize entropy_vector above for the first iteration
             # of the autofocus routine. Then need to append each measurement to the

--- a/src/navigate/model/features/autofocus.py
+++ b/src/navigate/model/features/autofocus.py
@@ -651,6 +651,11 @@ class Autofocus:
                 f"entropy: {entropy[0]}"
             )
             self.plot_data.append([self.f_pos, entropy[0]])
+            progress_snapshot = [
+                [float(position), float(metric)]
+                for position, metric in self.plot_data
+            ]
+            self.model.event_queue.put(("autofocus_progress", progress_snapshot))
             # Need to initialize entropy above for the first iteration of the autofocus
             # routine. Need to initialize entropy_vector above for the first iteration
             # of the autofocus routine. Then need to append each measurement to the

--- a/src/navigate/model/features/autofocus.py
+++ b/src/navigate/model/features/autofocus.py
@@ -282,10 +282,7 @@ class Autofocus:
         dict
             Autofocus parameters.
         """
-        frame_num = self.get_autofocus_frame_num()
-        if frame_num < 1:
-            return
-
+        self._freeze_scan_settings()
         bounds_error = self.get_initial_scan_bounds_error()
         if bounds_error:
             if hasattr(self.model, "logger"):
@@ -296,6 +293,10 @@ class Autofocus:
                 self.model.show_img_pipe.send("stop")
             if hasattr(self.model, "is_acquiring"):
                 self.model.is_acquiring = False
+            return
+
+        frame_num = self.get_autofocus_frame_num()
+        if frame_num < 1:
             return
 
         # Opens correct shutter and puts all signals to false
@@ -405,6 +406,30 @@ class Autofocus:
         self.fine_step_size = float(settings["fine_step_size"])
         self._scan_settings_frozen = True
 
+        if self.coarse_step_size == 0 or self.coarse_range == 0:
+            self.coarse_selected = False
+        else:
+            self.coarse_range = (
+                -1 * self.coarse_range if self.coarse_range < 0 else self.coarse_range
+            )
+            self.coarse_step_size = (
+                -1 * self.coarse_step_size
+                if self.coarse_step_size < 0
+                else self.coarse_step_size
+            )
+
+        if self.fine_step_size == 0 or self.fine_range == 0:
+            self.fine_selected = False
+        else:
+            self.fine_range = (
+                -1 * self.fine_range if self.fine_range < 0 else self.fine_range
+            )
+            self.fine_step_size = (
+                -1 * self.fine_step_size
+                if self.fine_step_size < 0
+                else self.fine_step_size
+            )
+
     def _get_frozen_scan_settings(self):
         """Return a serializable copy of the frozen motion settings."""
         self._freeze_scan_settings()
@@ -438,9 +463,7 @@ class Autofocus:
             return None
         self._freeze_scan_settings()
         center = float(
-            self.model.configuration["experiment"]["StageParameters"][
-                self.device_ref
-            ]
+            self.model.configuration["experiment"]["StageParameters"][self.device_ref]
         )
         if self.coarse_selected:
             positions = plan_autofocus_positions(
@@ -456,6 +479,12 @@ class Autofocus:
                 self.fine_step_size,
             )
             return self._stage_scan_bounds_error("fine", positions)
+        if not self.coarse_selected and not self.fine_selected:
+            return (
+                f"Coarse/Fine settings error!\n\n"
+                "Select at least one mode: Coarse or Fine.\n"
+                "Please ensure the range and step size are greater than zero."
+            )
         return None
 
     @staticmethod
@@ -684,8 +713,7 @@ class Autofocus:
             )
             self.plot_data.append([self.f_pos, entropy[0]])
             progress_snapshot = [
-                [float(position), float(metric)]
-                for position, metric in self.plot_data
+                [float(position), float(metric)] for position, metric in self.plot_data
             ]
             progress_queue = getattr(self.model, "autofocus_progress_queue", None)
             if progress_queue is not None:

--- a/src/navigate/model/features/autofocus.py
+++ b/src/navigate/model/features/autofocus.py
@@ -687,15 +687,22 @@ class Autofocus:
                 [float(position), float(metric)]
                 for position, metric in self.plot_data
             ]
-            try:
-                self.model.event_queue.put_nowait(
-                    ("autofocus_progress", progress_snapshot)
-                )
-            except Full:
-                self.model.logger.debug(
-                    "Dropping autofocus progress snapshot because the event queue "
-                    "is full."
-                )
+            progress_queue = getattr(self.model, "autofocus_progress_queue", None)
+            if progress_queue is not None:
+                try:
+                    progress_queue.put_nowait(progress_snapshot)
+                except Full:
+                    try:
+                        progress_queue.get_nowait()
+                    except Empty:
+                        pass
+                    try:
+                        progress_queue.put_nowait(progress_snapshot)
+                    except Full:
+                        self.model.logger.debug(
+                            "Dropping an autofocus progress snapshot after a "
+                            "concurrent queue update."
+                        )
             # Need to initialize entropy above for the first iteration of the autofocus
             # routine. Need to initialize entropy_vector above for the first iteration
             # of the autofocus routine. Then need to append each measurement to the

--- a/src/navigate/model/features/autofocus.py
+++ b/src/navigate/model/features/autofocus.py
@@ -43,6 +43,71 @@ from scipy.interpolate import UnivariateSpline
 # Local imports
 from navigate.model.features.feature_container import load_features
 from navigate.model.analysis.image_contrast import fast_normalized_dct_shannon_entropy
+from navigate.model.utils.exceptions import UserVisibleException
+
+
+def plan_autofocus_positions(center, scan_range, step_size):
+    """Return the exact autofocus positions for one scan.
+
+    Parameters
+    ----------
+    center : float
+        Position around which the scan is constructed.
+    scan_range : float
+        Requested scan range.
+    step_size : float
+        Distance between measurements.
+
+    Returns
+    -------
+    tuple[float, ...]
+        Ordered positions used by autofocus.
+    """
+    frame_count = int(scan_range // step_size) + 1
+    first_position = center - (frame_count // 2) * step_size
+    return tuple(first_position + index * step_size for index in range(frame_count))
+
+
+def _format_position(position):
+    """Format a stage position without obscuring a bounds violation."""
+    return f"{float(position):g}"
+
+
+def autofocus_bounds_error(scan_name, positions, minimum, maximum, device_ref):
+    """Describe an autofocus trajectory that exceeds enabled stage limits.
+
+    Parameters
+    ----------
+    scan_name : str
+        User-facing scan name, such as ``"coarse"`` or ``"fine"``.
+    positions : Sequence[float]
+        Exact ordered stage targets.
+    minimum : float
+        Configured lower stage limit.
+    maximum : float
+        Configured upper stage limit.
+    device_ref : str
+        Selected stage-axis reference.
+
+    Returns
+    -------
+    str or None
+        An actionable diagnostic, or ``None`` when every position is allowed.
+    """
+    if not positions:
+        return None
+    requested_minimum = min(positions)
+    requested_maximum = max(positions)
+    if requested_minimum >= minimum and requested_maximum <= maximum:
+        return None
+
+    stage_name = "focus-stage" if device_ref == "f" else f"{device_ref}-stage"
+    return (
+        f"The requested {scan_name} scan "
+        f"({_format_position(requested_minimum)} to "
+        f"{_format_position(requested_maximum)} µm) exceeds the {stage_name} "
+        f"limits ({_format_position(minimum)} to {_format_position(maximum)} µm)."
+    )
 
 
 def power_tent(x, x_offset, y_offset, amplitude, sigma, alpha):
@@ -152,6 +217,12 @@ class Autofocus:
         #: int: Coarse steps
         self.coarse_steps = None
 
+        #: tuple: Ordered coarse scan positions
+        self.coarse_positions = ()
+
+        #: tuple: Ordered fine scan positions
+        self.fine_positions = ()
+
         #: int: Signal id
         self.signal_id = None
 
@@ -204,6 +275,18 @@ class Autofocus:
         """
         frame_num = self.get_autofocus_frame_num()
         if frame_num < 1:
+            return
+
+        bounds_error = self.get_initial_scan_bounds_error()
+        if bounds_error:
+            if hasattr(self.model, "logger"):
+                self.model.logger.warning(bounds_error)
+            if hasattr(self.model, "event_queue"):
+                self.model.event_queue.put(("warning", bounds_error))
+            if hasattr(self.model, "show_img_pipe"):
+                self.model.show_img_pipe.send("stop")
+            if hasattr(self.model, "is_acquiring"):
+                self.model.is_acquiring = False
             return
 
         # Opens correct shutter and puts all signals to false
@@ -275,14 +358,65 @@ class Autofocus:
         ][self.device][self.device_ref]
         frames = 0
         if settings["coarse_selected"]:
-            coarse_range = float(settings["coarse_range"])
-            coarse_step_size = float(settings["coarse_step_size"])
-            frames = int(coarse_range // coarse_step_size) + 1
+            frames = len(
+                plan_autofocus_positions(
+                    0,
+                    float(settings["coarse_range"]),
+                    float(settings["coarse_step_size"]),
+                )
+            )
         if settings["fine_selected"]:
-            fine_range = float(settings["fine_range"])
-            fine_step_size = float(settings["fine_step_size"])
-            frames += int(fine_range // fine_step_size) + 1
+            frames += len(
+                plan_autofocus_positions(
+                    0,
+                    float(settings["fine_range"]),
+                    float(settings["fine_step_size"]),
+                )
+            )
         return frames
+
+    def _stage_scan_bounds_error(self, scan_name, positions):
+        """Return a stage-bounds diagnostic for an exact scan trajectory."""
+        if self.device != "stage":
+            return None
+        stage = self.model.active_microscope.stages.get(self.device_ref)
+        if stage is None or not stage.stage_limits:
+            return None
+        return autofocus_bounds_error(
+            scan_name,
+            positions,
+            getattr(stage, f"{self.device_ref}_min"),
+            getattr(stage, f"{self.device_ref}_max"),
+            self.device_ref,
+        )
+
+    def get_initial_scan_bounds_error(self):
+        """Validate the scan whose center is knowable before acquisition."""
+        if self.device != "stage":
+            return None
+        settings = self.model.configuration["experiment"]["AutoFocusParameters"][
+            self.model.active_microscope_name
+        ][self.device][self.device_ref]
+        center = float(
+            self.model.configuration["experiment"]["StageParameters"][
+                self.device_ref
+            ]
+        )
+        if settings["coarse_selected"]:
+            positions = plan_autofocus_positions(
+                center,
+                float(settings["coarse_range"]),
+                float(settings["coarse_step_size"]),
+            )
+            return self._stage_scan_bounds_error("coarse", positions)
+        if settings["fine_selected"]:
+            positions = plan_autofocus_positions(
+                center,
+                float(settings["fine_range"]),
+                float(settings["fine_step_size"]),
+            )
+            return self._stage_scan_bounds_error("fine", positions)
+        return None
 
     @staticmethod
     def get_steps(ranges, step_size):
@@ -302,7 +436,7 @@ class Autofocus:
         pos_offset : float
             Need to figure out.
         """
-        steps = ranges // step_size + 1
+        steps = len(plan_autofocus_positions(0, ranges, step_size))
         pos_offset = (steps // 2) * step_size + step_size
         return steps, pos_offset
 
@@ -312,6 +446,23 @@ class Autofocus:
             self.model.active_microscope.prepare_channel(self.target_channel)
         else:
             self.model.active_microscope.prepare_next_channel()
+
+    def _move_stage_or_raise(self, position):
+        """Move the selected autofocus stage or fail before frame queueing."""
+        moved = self.model.move_stage(
+            {f"{self.device_ref}_abs": position}, wait_until_done=True
+        )
+        if not moved:
+            stage_name = (
+                "focus stage" if self.device_ref == "f" else f"{self.device_ref} stage"
+            )
+            raise UserVisibleException(
+                f"Autofocus could not move the {stage_name} to "
+                f"{_format_position(position)} µm. The scan was stopped."
+            )
+        self.model.logger.debug(
+            f"*** Autofocus move stage: ({self.device_ref}, {position})"
+        )
 
     def pre_func_signal(self):
         """Prepare the autofocus routine."""
@@ -328,20 +479,34 @@ class Autofocus:
             self.focus_pos = 0
         self.total_frame_num = self.get_autofocus_frame_num()  # Total frame num
         self.coarse_steps, self.init_pos = 0, 0
+        self.coarse_positions = ()
+        self.fine_positions = ()
 
         if settings["fine_selected"]:
             self.fine_step_size = float(settings["fine_step_size"])
-            fine_steps, self.fine_pos_offset = self.get_steps(
-                float(settings["fine_range"]), self.fine_step_size
+            self.fine_positions = plan_autofocus_positions(
+                self.focus_pos,
+                float(settings["fine_range"]),
+                self.fine_step_size,
             )
-            self.init_pos = self.focus_pos - self.fine_pos_offset
+            self.init_pos = self.fine_positions[0] - self.fine_step_size
 
         if settings["coarse_selected"]:
             self.coarse_step_size = float(settings["coarse_step_size"])
-            self.coarse_steps, coarse_pos_offset = self.get_steps(
-                float(settings["coarse_range"]), self.coarse_step_size
+            self.coarse_positions = plan_autofocus_positions(
+                self.focus_pos,
+                float(settings["coarse_range"]),
+                self.coarse_step_size,
             )
-            self.init_pos = self.focus_pos - coarse_pos_offset
+            self.coarse_steps = len(self.coarse_positions)
+            self.init_pos = self.coarse_positions[0] - self.coarse_step_size
+            bounds_error = self._stage_scan_bounds_error(
+                "coarse", self.coarse_positions
+            )
+        else:
+            bounds_error = self._stage_scan_bounds_error("fine", self.fine_positions)
+        if bounds_error:
+            raise UserVisibleException(bounds_error)
         self.signal_id = 0
 
     def _wait_for_focus_position(self):
@@ -363,14 +528,9 @@ class Autofocus:
         """Run the autofocus routine."""
 
         if self.signal_id < self.coarse_steps:
-            self.init_pos += self.coarse_step_size
+            self.init_pos = self.coarse_positions[self.signal_id]
             if self.device == "stage":
-                self.model.move_stage(
-                    {f"{self.device_ref}_abs": self.init_pos}, wait_until_done=True
-                )
-                self.model.logger.debug(
-                    f"*** Autofocus move stage: ({self.device_ref}, {self.init_pos})"
-                )
+                self._move_stage_or_raise(self.init_pos)
             elif self.device == "remote_focus":
                 self.model.active_microscope.move_remote_focus(self.init_pos)
                 self.model.logger.debug(
@@ -385,16 +545,23 @@ class Autofocus:
                 focus_position = self._wait_for_focus_position()
                 if focus_position is None:
                     return None
-                self.init_pos = focus_position
-                self.init_pos -= self.fine_pos_offset
-            self.init_pos += self.fine_step_size
+                settings = self.model.configuration["experiment"][
+                    "AutoFocusParameters"
+                ][self.model.active_microscope_name][self.device][self.device_ref]
+                self.fine_positions = plan_autofocus_positions(
+                    focus_position,
+                    float(settings["fine_range"]),
+                    self.fine_step_size,
+                )
+                bounds_error = self._stage_scan_bounds_error(
+                    "fine", self.fine_positions
+                )
+                if bounds_error:
+                    raise UserVisibleException(bounds_error)
+            fine_index = self.signal_id - self.coarse_steps
+            self.init_pos = self.fine_positions[fine_index]
             if self.device == "stage":
-                self.model.move_stage(
-                    {f"{self.device_ref}_abs": self.init_pos}, wait_until_done=True
-                )
-                self.model.logger.debug(
-                    f"*** Autofocus move stage: ({self.device_ref}, {self.init_pos})"
-                )
+                self._move_stage_or_raise(self.init_pos)
             elif self.device == "remote_focus":
                 self.model.active_microscope.move_remote_focus(self.init_pos)
                 self.model.logger.debug(
@@ -414,12 +581,7 @@ class Autofocus:
                 return None
             self.init_pos = focus_position
             if self.device == "stage":
-                self.model.move_stage(
-                    {f"{self.device_ref}_abs": self.init_pos}, wait_until_done=True
-                )
-                self.model.logger.debug(
-                    f"*** Autofocus move stage: ({self.device_ref}, {self.init_pos})"
-                )
+                self._move_stage_or_raise(self.init_pos)
             elif self.device == "remote_focus":
                 self.model.active_microscope.move_remote_focus(self.init_pos)
                 self.model.logger.debug(

--- a/src/navigate/model/model.py
+++ b/src/navigate/model/model.py
@@ -97,6 +97,7 @@ class Model:
         configuration: Optional[Dict[str, Any]] = None,
         event_queue: multiprocessing.Queue = None,
         log_queue: Optional[multiprocessing.Queue] = None,
+        autofocus_progress_queue: multiprocessing.Queue = None,
     ) -> None:
         """Initialize the Model.
 
@@ -110,6 +111,8 @@ class Model:
             Event queue. Receives events from the controller.
         log_queue : Optional[multiprocessing.Queue]
             Log queue. Receives log messages from the controller.
+        autofocus_progress_queue : multiprocessing.Queue
+            Single-slot queue for replaceable autofocus progress snapshots.
         """
         # Set up logging
         log_setup("logging.yml", queue=log_queue)
@@ -227,6 +230,9 @@ class Model:
         # waveform queue
         #: multiprocessing.Queue: Waveform queue.
         self.event_queue = event_queue
+
+        #: multiprocessing.Queue: Replaceable autofocus plotting snapshots.
+        self.autofocus_progress_queue = autofocus_progress_queue
 
         # frame signal id
         #: int: Frame ID.
@@ -1901,6 +1907,7 @@ class ASIModel(Model):
         configuration: Optional[Dict[str, Any]] = None,
         event_queue: multiprocessing.Queue = None,
         log_queue: Optional[multiprocessing.Queue] = None,
+        autofocus_progress_queue: multiprocessing.Queue = None,
     ) -> None:
         """Initialize the ASI Model.
 
@@ -1914,8 +1921,16 @@ class ASIModel(Model):
             Event queue for communication with the controller. Default is None.
         log_queue : multiprocessing.Queue
             Log queue for logging messages. Default is None.
+        autofocus_progress_queue : multiprocessing.Queue
+            Single-slot queue for replaceable autofocus progress snapshots.
         """
-        super().__init__(args, configuration, event_queue, log_queue)
+        super().__init__(
+            args,
+            configuration,
+            event_queue,
+            log_queue,
+            autofocus_progress_queue,
+        )
 
         self.acquisition_modes_feature_setting["z-stack"] = [
             (

--- a/src/navigate/view/popups/autofocus_setting_popup.py
+++ b/src/navigate/view/popups/autofocus_setting_popup.py
@@ -283,6 +283,23 @@ class AutofocusPopup:
             self.inputs[setting_names[i] + "_step_size"] = widget
             self.setting_vars[setting_names[i] + "_step_size"] = widget.get_variable()
 
+        self.bounds_warning_var = tk.StringVar(value="")
+        self.bounds_warning_label = ttk.Label(
+            scan_frame,
+            textvariable=self.bounds_warning_var,
+            foreground=get_theme_color("danger", "red"),
+            justify=tk.LEFT,
+            wraplength=650,
+        )
+        self.bounds_warning_label.grid(
+            row=3,
+            column=0,
+            columnspan=3,
+            sticky=tk.EW,
+            padx=get_theme_space_px(5),
+            pady=get_theme_padding_px((2, 6)),
+        )
+
         # Section 3.
         options_frame = ttk.Labelframe(
             content_frame,

--- a/test/controller/sub_controllers/test_advanced_stage_settings.py
+++ b/test/controller/sub_controllers/test_advanced_stage_settings.py
@@ -8,7 +8,9 @@ from navigate.controller.sub_controllers.stages_advanced import (
 )
 
 
-def test_limit_edit_immediately_refreshes_open_autofocus_popup(dummy_controller):
+def test_limit_edit_immediately_refreshes_open_autofocus_popup(
+    dummy_controller, monkeypatch
+):
     controller = AdvancedStageParametersController.__new__(
         AdvancedStageParametersController
     )
@@ -16,7 +18,18 @@ def test_limit_edit_immediately_refreshes_open_autofocus_popup(dummy_controller)
         "microscope_name"
     ]
     refresh_bounds = MagicMock()
-    dummy_controller._refresh_autofocus_bounds = refresh_bounds
+    monkeypatch.setattr(
+        dummy_controller,
+        "_refresh_autofocus_bounds",
+        refresh_bounds,
+        raising=False,
+    )
+    stage_configuration = dummy_controller.configuration["configuration"][
+        "microscopes"
+    ][microscope_name]["stage"]
+    monkeypatch.setitem(
+        stage_configuration, "f_max", stage_configuration["f_max"]
+    )
     controller.parent_controller = dummy_controller
     controller.current_microscope = microscope_name
     controller.stage_dict = {}
@@ -28,10 +41,7 @@ def test_limit_edit_immediately_refreshes_open_autofocus_popup(dummy_controller)
 
     assert controller.stage_dict["f_max"] == 1234
     assert (
-        dummy_controller.configuration["configuration"]["microscopes"][
-            microscope_name
-        ]["stage"]["f_max"]
-        == 1234
+        stage_configuration["f_max"] == 1234
     )
     refresh_bounds.assert_called_once_with()
 

--- a/test/controller/sub_controllers/test_advanced_stage_settings.py
+++ b/test/controller/sub_controllers/test_advanced_stage_settings.py
@@ -1,10 +1,39 @@
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from navigate.config.config import get_navigate_path
 from navigate.controller.sub_controllers.stages_advanced import (
     AdvancedStageParametersController,
 )
+
+
+def test_limit_edit_immediately_refreshes_open_autofocus_popup(dummy_controller):
+    controller = AdvancedStageParametersController.__new__(
+        AdvancedStageParametersController
+    )
+    microscope_name = dummy_controller.configuration["experiment"]["MicroscopeState"][
+        "microscope_name"
+    ]
+    refresh_bounds = MagicMock()
+    dummy_controller._refresh_autofocus_bounds = refresh_bounds
+    controller.parent_controller = dummy_controller
+    controller.current_microscope = microscope_name
+    controller.stage_dict = {}
+    controller.view = SimpleNamespace(
+        spinboxes={"f_max": MagicMock(get=MagicMock(return_value="1234.5"))}
+    )
+
+    controller.update_spinboxes("f_max")
+
+    assert controller.stage_dict["f_max"] == 1234
+    assert (
+        dummy_controller.configuration["configuration"]["microscopes"][
+            microscope_name
+        ]["stage"]["f_max"]
+        == 1234
+    )
+    refresh_bounds.assert_called_once_with()
 
 
 def test_save_stage_parameters_writes_to_parent_configuration_path(

--- a/test/controller/sub_controllers/test_autofocus.py
+++ b/test/controller/sub_controllers/test_autofocus.py
@@ -32,7 +32,7 @@
 #
 
 # Standard library imports
-from unittest.mock import MagicMock, patch
+from unittest.mock import call, MagicMock, patch
 from types import SimpleNamespace
 
 # Third party imports
@@ -591,3 +591,218 @@ class TestAutofocusPopupController:
         data = [x_data, y_data]
         self.autofocus_controller.display_plot([data, False, True])
         pass
+
+    def test_progress_updates_are_coalesced_to_latest_snapshot(self):
+        widget = self.autofocus_controller.autofocus_fig.canvas.get_tk_widget()
+        first = [[1.0, 10.0]]
+        latest = [[1.0, 10.0], [2.0, 20.0]]
+
+        with patch.object(widget, "after_idle", return_value="after-id") as after_idle:
+            self.autofocus_controller.display_autofocus_progress(first)
+            self.autofocus_controller.display_autofocus_progress(latest)
+
+        after_idle.assert_called_once_with(
+            self.autofocus_controller._flush_pending_autofocus_update
+        )
+        assert np.array_equal(
+            self.autofocus_controller._pending_autofocus_data,
+            np.asarray(latest),
+        )
+
+        with patch.object(
+            self.autofocus_controller, "_update_progress_plot"
+        ) as update_plot:
+            self.autofocus_controller._flush_pending_autofocus_update()
+
+        update_plot.assert_called_once()
+        assert np.array_equal(update_plot.call_args.args[0], np.asarray(latest))
+        assert self.autofocus_controller._pending_autofocus_data is None
+        assert self.autofocus_controller._autofocus_after_id is None
+
+    def test_progress_received_off_main_thread_is_redispatched(self, monkeypatch):
+        run_on_main = MagicMock()
+        monkeypatch.setattr(
+            self.autofocus_controller.parent_controller,
+            "_run_on_main_thread",
+            run_on_main,
+            raising=False,
+        )
+        self.autofocus_controller._main_thread_ident = 0
+        data = [[1.0, 10.0]]
+
+        self.autofocus_controller.display_autofocus_progress(data)
+
+        run_on_main.assert_called_once_with(
+            self.autofocus_controller.display_autofocus_progress,
+            data,
+            wait=False,
+        )
+
+    def test_custom_events_include_autofocus_progress(self):
+        assert (
+            self.autofocus_controller.custom_events["autofocus_progress"]
+            == self.autofocus_controller.display_autofocus_progress
+        )
+
+    def test_progress_plot_reuses_one_measured_data_artist(self):
+        self.autofocus_controller._initialize_progress_plot()
+        artist = self.autofocus_controller._autofocus_artist
+        line_count = len(self.autofocus_controller.autofocus_coarse.lines)
+
+        with patch.object(self.autofocus_controller, "_render_autofocus"):
+            self.autofocus_controller._update_progress_plot(
+                np.asarray([[1.0, 10.0], [2.0, 20.0]])
+            )
+            self.autofocus_controller._update_progress_plot(
+                np.asarray([[1.0, 10.0], [2.0, 20.0], [3.0, 15.0]])
+            )
+
+        assert self.autofocus_controller._autofocus_artist is artist
+        assert len(self.autofocus_controller.autofocus_coarse.lines) == line_count
+        assert np.array_equal(artist.get_xdata(), np.asarray([1.0, 2.0, 3.0]))
+        assert np.array_equal(artist.get_ydata(), np.asarray([10.0, 20.0, 15.0]))
+
+    def test_progress_plot_presizes_x_axis_from_initial_scan_plan(self):
+        settings = self.autofocus_controller.setting_dict[
+            self.autofocus_controller.microscope_name
+        ]["stage"]["f"]
+        settings.update(
+            {
+                "coarse_selected": True,
+                "coarse_range": 500,
+                "coarse_step_size": 50,
+                "fine_selected": True,
+            }
+        )
+        self.autofocus_controller.parent_controller.configuration["experiment"][
+            "StageParameters"
+        ]["f"] = 1000
+
+        self.autofocus_controller._initialize_progress_plot()
+
+        assert self.autofocus_controller._last_xlim[0] < 750
+        assert self.autofocus_controller._last_xlim[1] > 1250
+
+    def test_axis_expansion_forces_one_full_redraw_then_resumes_blitting(self):
+        self.autofocus_controller._initialize_progress_plot()
+        self.autofocus_controller._last_xlim = (0.0, 2.0)
+        self.autofocus_controller._last_ylim = (0.0, 20.0)
+        self.autofocus_controller._force_full_redraw = False
+
+        with patch.object(
+            self.autofocus_controller, "_render_autofocus"
+        ) as render:
+            self.autofocus_controller._update_progress_plot(
+                np.asarray([[1.0, 10.0], [3.0, 15.0]])
+            )
+            self.autofocus_controller._update_progress_plot(
+                np.asarray([[1.0, 10.0], [2.5, 15.0]])
+            )
+
+        assert render.call_args_list == [
+            call(force_full_redraw=True),
+            call(force_full_redraw=False),
+        ]
+
+    def test_final_plot_retains_measurements_and_adds_fit_overlay(self):
+        self.autofocus_controller._initialize_progress_plot()
+        measured = [[0.0, 1.0], [1.0, 3.0], [2.0, 2.0]]
+        fit = [[0.0, 1.0], [1.0, 3.0], [2.0, 1.0]]
+
+        self.autofocus_controller.display_plot([measured, False, True])
+        measured_line_count = len(self.autofocus_controller.autofocus_coarse.lines)
+        self.autofocus_controller.display_plot([fit, True, False])
+
+        assert measured_line_count == 3
+        assert len(self.autofocus_controller.autofocus_coarse.lines) == 4
+        assert self.autofocus_controller._autofocus_artist is None
+        assert np.array_equal(
+            self.autofocus_controller.autofocus_coarse.lines[0].get_xdata(),
+            np.asarray([0.0, 1.0, 2.0]),
+        )
+
+    def test_stop_acquisition_leaves_partial_progress_visible(self, monkeypatch):
+        parent = self.autofocus_controller.parent_controller
+        acquire_button = parent.view.acquire_bar.acquire_btn
+        monkeypatch.setattr(
+            parent,
+            "acquire_bar_controller",
+            SimpleNamespace(
+                is_acquiring=True,
+                mode="live",
+                view=SimpleNamespace(acquire_btn=acquire_button),
+            ),
+            raising=False,
+        )
+        monkeypatch.setattr(parent, "execute", MagicMock())
+        self.autofocus_controller._initialize_progress_plot()
+        with patch.object(self.autofocus_controller, "_render_autofocus"):
+            self.autofocus_controller._update_progress_plot(
+                np.asarray([[1.0, 10.0], [2.0, 20.0]])
+            )
+        artist = self.autofocus_controller._autofocus_artist
+
+        self.autofocus_controller.stop_acquisition()
+
+        assert self.autofocus_controller._autofocus_artist is artist
+        assert np.array_equal(artist.get_xdata(), np.asarray([1.0, 2.0]))
+        assert np.array_equal(artist.get_ydata(), np.asarray([10.0, 20.0]))
+
+
+def build_render_controller(blit_supported=True):
+    controller = AutofocusPopupController.__new__(AutofocusPopupController)
+    controller.autofocus_coarse = MagicMock()
+    controller.autofocus_coarse.bbox = object()
+    controller._autofocus_artist = MagicMock()
+    controller._autofocus_background = object()
+    controller._blit_supported = blit_supported
+    controller._force_full_redraw = False
+    controller._last_render_used_blit = False
+    controller.autofocus_fig = SimpleNamespace(canvas=MagicMock())
+    return controller
+
+
+def test_render_autofocus_uses_cached_background_blit():
+    controller = build_render_controller()
+
+    controller._render_autofocus(force_full_redraw=False)
+
+    canvas = controller.autofocus_fig.canvas
+    canvas.draw.assert_not_called()
+    canvas.restore_region.assert_called_once_with(controller._autofocus_background)
+    controller.autofocus_coarse.draw_artist.assert_called_once_with(
+        controller._autofocus_artist
+    )
+    canvas.blit.assert_called_once_with(controller.autofocus_coarse.bbox)
+    assert controller._last_render_used_blit is True
+
+
+def test_render_autofocus_falls_back_to_full_draw_without_blit():
+    controller = build_render_controller(blit_supported=False)
+
+    controller._render_autofocus(force_full_redraw=False)
+
+    controller.autofocus_fig.canvas.draw.assert_called_once_with()
+    controller.autofocus_fig.canvas.blit.assert_not_called()
+    assert controller._last_render_used_blit is False
+
+
+def test_invalidate_autofocus_blit_cache_forces_full_redraw():
+    controller = build_render_controller()
+
+    controller._invalidate_autofocus_blit_cache()
+
+    assert controller._autofocus_background is None
+    assert controller._force_full_redraw is True
+
+
+def test_autofocus_draw_event_refreshes_background_cache():
+    controller = build_render_controller()
+    refreshed_background = object()
+    controller.autofocus_fig.canvas.copy_from_bbox.return_value = refreshed_background
+
+    controller._on_autofocus_draw(
+        SimpleNamespace(canvas=controller.autofocus_fig.canvas)
+    )
+
+    assert controller._autofocus_background is refreshed_background

--- a/test/controller/sub_controllers/test_autofocus.py
+++ b/test/controller/sub_controllers/test_autofocus.py
@@ -644,6 +644,16 @@ class TestAutofocusPopupController:
             == self.autofocus_controller.display_autofocus_progress
         )
 
+    def test_close_popup_unregisters_autofocus_event_handlers(self):
+        parent = self.autofocus_controller.parent_controller
+        parent.af_popup_controller = self.autofocus_controller
+
+        self.autofocus_controller.close_popup()
+
+        for event_name in self.autofocus_controller.custom_events:
+            assert event_name not in parent.event_listeners
+        assert not hasattr(parent, "af_popup_controller")
+
     def test_progress_plot_reuses_one_measured_data_artist(self):
         self.autofocus_controller._initialize_progress_plot()
         artist = self.autofocus_controller._autofocus_artist

--- a/test/controller/sub_controllers/test_autofocus.py
+++ b/test/controller/sub_controllers/test_autofocus.py
@@ -74,12 +74,82 @@ class TestAutofocusPopupController:
             Dummy controller for testing
 
         """
-        if hasattr(dummy_controller, "autofocus_calibration_controller"):
-            dummy_controller.autofocus_calibration_controller.reference = None
+        stage_parameters = dummy_controller.configuration["experiment"][
+            "StageParameters"
+        ]
+        original_stage_parameters = dict(stage_parameters)
+        microscope_state = dummy_controller.configuration["experiment"][
+            "MicroscopeState"
+        ]
+        autofocus_settings = dummy_controller.configuration["experiment"][
+            "AutoFocusParameters"
+        ][microscope_state["microscope_name"]]["stage"]["f"]
+        original_autofocus_settings = dict(autofocus_settings)
+        channels = microscope_state["channels"]
+        original_defocus = {
+            channel_key: channel["defocus"]
+            for channel_key, channel in channels.items()
+        }
+        original_get_stage_position_limits = (
+            dummy_controller.configuration_controller.get_stage_position_limits
+        )
+        autofocus_state_keys = ("autofocus_device", "autofocus_device_ref")
+        missing = object()
+        original_autofocus_state = {
+            key: microscope_state.get(key, missing) for key in autofocus_state_keys
+        }
+        calibration_controller = getattr(
+            dummy_controller, "autofocus_calibration_controller", None
+        )
+        original_reference = (
+            calibration_controller.reference
+            if calibration_controller is not None
+            else None
+        )
+
+        stage_parameters["f"] = 0
+        stage_parameters["limits"] = False
+        autofocus_settings.update(
+            {
+                "coarse_selected": True,
+                "coarse_range": 500,
+                "coarse_step_size": 50,
+                "fine_selected": True,
+                "fine_range": 50,
+                "fine_step_size": 5,
+            }
+        )
+        if calibration_controller is not None:
+            calibration_controller.reference = None
         autofocus_popup = AutofocusPopup(dummy_controller.view)
         self.autofocus_controller = AutofocusPopupController(
             autofocus_popup, dummy_controller
         )
+        try:
+            yield
+        finally:
+            popup = self.autofocus_controller.view.popup
+            if popup.winfo_exists():
+                self.autofocus_controller.close_popup()
+            dummy_controller.configuration_controller.get_stage_position_limits = (
+                original_get_stage_position_limits
+            )
+            stage_parameters.clear()
+            stage_parameters.update(original_stage_parameters)
+            autofocus_settings.clear()
+            autofocus_settings.update(original_autofocus_settings)
+            for channel_key, defocus in original_defocus.items():
+                channels[channel_key]["defocus"] = defocus
+            for key, value in original_autofocus_state.items():
+                if value is missing:
+                    microscope_state.pop(key, None)
+                else:
+                    microscope_state[key] = value
+            calibration_controller = getattr(
+                dummy_controller, "autofocus_calibration_controller", None
+            )
+            if calibration_controller is not None:
+                calibration_controller.reference = original_reference
 
     def test_init(self):
         """Tests that the controller is initialized correctly

--- a/test/controller/sub_controllers/test_autofocus.py
+++ b/test/controller/sub_controllers/test_autofocus.py
@@ -74,6 +74,8 @@ class TestAutofocusPopupController:
             Dummy controller for testing
 
         """
+        if hasattr(dummy_controller, "autofocus_calibration_controller"):
+            dummy_controller.autofocus_calibration_controller.reference = None
         autofocus_popup = AutofocusPopup(dummy_controller.view)
         self.autofocus_controller = AutofocusPopupController(
             autofocus_popup, dummy_controller
@@ -652,7 +654,31 @@ class TestAutofocusPopupController:
 
         for event_name in self.autofocus_controller.custom_events:
             assert event_name not in parent.event_listeners
+        assert "autofocus_complete" in parent.event_listeners
         assert not hasattr(parent, "af_popup_controller")
+
+    def test_close_mid_defocus_keeps_completion_processing_alive(self):
+        parent = self.autofocus_controller.parent_controller
+        parent.af_popup_controller = self.autofocus_controller
+        channels = parent.configuration["experiment"]["MicroscopeState"]["channels"]
+        channels["channel_1"]["defocus"] = 1.5
+        channels["channel_2"]["defocus"] = 4.0
+
+        self.autofocus_controller.close_popup()
+        parent.event_listeners["autofocus_complete"](
+            {
+                "channel": "channel_1",
+                "focus_position": 100.0,
+                "calibration_action": "capture_reference",
+            }
+        )
+
+        assert parent.autofocus_calibration_controller.reference == {
+            "channel": "channel_1",
+            "focus_position": 100.0,
+        }
+        assert channels["channel_1"]["defocus"] == pytest.approx(0.0)
+        assert channels["channel_2"]["defocus"] == pytest.approx(2.5)
 
     def test_progress_plot_reuses_one_measured_data_artist(self):
         self.autofocus_controller._initialize_progress_plot()

--- a/test/controller/sub_controllers/test_autofocus.py
+++ b/test/controller/sub_controllers/test_autofocus.py
@@ -87,8 +87,7 @@ class TestAutofocusPopupController:
         original_autofocus_settings = dict(autofocus_settings)
         channels = microscope_state["channels"]
         original_defocus = {
-            channel_key: channel["defocus"]
-            for channel_key, channel in channels.items()
+            channel_key: channel["defocus"] for channel_key, channel in channels.items()
         }
         original_get_stage_position_limits = (
             dummy_controller.configuration_controller.get_stage_position_limits
@@ -168,18 +167,14 @@ class TestAutofocusPopupController:
         assert self.autofocus_controller.view.bounds_warning_var.get() == ""
         assert int(warning_label.grid_info()["row"]) == 3
         assert int(warning_label.grid_info()["columnspan"]) == 3
-        assert str(warning_label.cget("foreground")) == get_theme_color(
-            "danger", "red"
-        )
+        assert str(warning_label.cget("foreground")) == get_theme_color("danger", "red")
 
     def configure_focus_bounds(self, minimum=0, maximum=1000, enabled=True):
         parent = self.autofocus_controller.parent_controller
         parent.configuration["experiment"]["StageParameters"]["f"] = 0
         parent.configuration["experiment"]["StageParameters"]["limits"] = enabled
         parent.configuration_controller.get_stage_position_limits = MagicMock(
-            side_effect=lambda suffix: {
-                "f": minimum if suffix == "_min" else maximum
-            }
+            side_effect=lambda suffix: {"f": minimum if suffix == "_min" else maximum}
         )
         settings = self.autofocus_controller.setting_dict[
             self.autofocus_controller.microscope_name
@@ -212,21 +207,15 @@ class TestAutofocusPopupController:
         assert self.autofocus_controller.view.bounds_warning_var.get() == expected
         coarse_range = self.autofocus_controller.widgets["coarse_range"].widget
         fine_range = self.autofocus_controller.widgets["fine_range"].widget
-        assert str(coarse_range.cget("foreground")) == get_theme_color(
-            "danger", "red"
-        )
-        assert str(fine_range.cget("foreground")) == get_theme_color(
-            "text", "black"
-        )
+        assert str(coarse_range.cget("foreground")) == get_theme_color("danger", "red")
+        assert str(fine_range.cget("foreground")) == get_theme_color("text", "black")
 
         self.autofocus_controller.parent_controller.configuration["experiment"][
             "StageParameters"
         ]["f"] = 500
         assert self.autofocus_controller.refresh_bounds_validation() == []
         assert self.autofocus_controller.view.bounds_warning_var.get() == ""
-        assert str(coarse_range.cget("foreground")) == get_theme_color(
-            "text", "black"
-        )
+        assert str(coarse_range.cget("foreground")) == get_theme_color("text", "black")
 
     def test_refresh_bounds_validation_checks_fine_only(self):
         settings = self.configure_focus_bounds()
@@ -284,9 +273,12 @@ class TestAutofocusPopupController:
         self.configure_focus_bounds()
         parent = self.autofocus_controller.parent_controller
 
-        with patch.object(parent, "execute") as execute, patch(
-            "navigate.controller.sub_controllers.autofocus.messagebox.showerror"
-        ) as showerror:
+        with (
+            patch.object(parent, "execute") as execute,
+            patch(
+                "navigate.controller.sub_controllers.autofocus.messagebox.showerror"
+            ) as showerror,
+        ):
             self.autofocus_controller.start_autofocus()
 
         execute.assert_not_called()
@@ -296,6 +288,28 @@ class TestAutofocusPopupController:
                 "The requested coarse scan (-250 to 250 µm) exceeds the "
                 "focus-stage limits (0 to 1000 µm)."
             ),
+        )
+
+    def test_start_autofocus_requires_a_selected_scan_mode(self):
+        settings = self.configure_focus_bounds(enabled=False)
+        settings["coarse_selected"] = False
+        settings["fine_selected"] = False
+        self.autofocus_controller.view.setting_vars["coarse_selected"].set(False)
+        self.autofocus_controller.view.setting_vars["fine_selected"].set(False)
+        parent = self.autofocus_controller.parent_controller
+
+        with (
+            patch.object(parent, "execute") as execute,
+            patch(
+                "navigate.controller.sub_controllers.autofocus.messagebox.showerror"
+            ) as showerror,
+        ):
+            self.autofocus_controller.start_autofocus()
+
+        execute.assert_not_called()
+        showerror.assert_called_once_with(
+            title="Navigate",
+            message="Please select at least one mode: Coarse or Fine.",
         )
 
     def test_stop_acquisition_button_matches_start_button(self):
@@ -795,9 +809,7 @@ class TestAutofocusPopupController:
         self.autofocus_controller._last_ylim = (0.0, 20.0)
         self.autofocus_controller._force_full_redraw = False
 
-        with patch.object(
-            self.autofocus_controller, "_render_autofocus"
-        ) as render:
+        with patch.object(self.autofocus_controller, "_render_autofocus") as render:
             self.autofocus_controller._update_progress_plot(
                 np.asarray([[1.0, 10.0], [3.0, 15.0]])
             )

--- a/test/controller/sub_controllers/test_autofocus.py
+++ b/test/controller/sub_controllers/test_autofocus.py
@@ -42,6 +42,7 @@ import numpy as np
 # Local application imports
 from navigate.controller.sub_controllers import AutofocusPopupController
 from navigate.view.popups.autofocus_setting_popup import AutofocusPopup
+from navigate.view.theme import get_theme_color
 
 
 class TestAutofocusPopupController:
@@ -88,6 +89,142 @@ class TestAutofocusPopupController:
         """
         assert isinstance(self.autofocus_controller, AutofocusPopupController)
         assert self.autofocus_controller.view.popup.winfo_exists() == 1
+
+    def test_scan_parameters_reserve_inline_bounds_warning_row(self):
+        warning_label = self.autofocus_controller.view.bounds_warning_label
+
+        assert self.autofocus_controller.view.bounds_warning_var.get() == ""
+        assert int(warning_label.grid_info()["row"]) == 3
+        assert int(warning_label.grid_info()["columnspan"]) == 3
+        assert str(warning_label.cget("foreground")) == get_theme_color(
+            "danger", "red"
+        )
+
+    def configure_focus_bounds(self, minimum=0, maximum=1000, enabled=True):
+        parent = self.autofocus_controller.parent_controller
+        parent.configuration["experiment"]["StageParameters"]["f"] = 0
+        parent.configuration["experiment"]["StageParameters"]["limits"] = enabled
+        parent.configuration_controller.get_stage_position_limits = MagicMock(
+            side_effect=lambda suffix: {
+                "f": minimum if suffix == "_min" else maximum
+            }
+        )
+        settings = self.autofocus_controller.setting_dict[
+            self.autofocus_controller.microscope_name
+        ]["stage"]["f"]
+        settings.update(
+            {
+                "coarse_selected": True,
+                "coarse_range": 500,
+                "coarse_step_size": 50,
+                "fine_selected": False,
+                "fine_range": 50,
+                "fine_step_size": 5,
+            }
+        )
+        for key, value in settings.items():
+            if key in self.autofocus_controller.view.setting_vars:
+                self.autofocus_controller.view.setting_vars[key].set(value)
+        return settings
+
+    def test_refresh_bounds_validation_marks_and_clears_coarse_range(self):
+        self.configure_focus_bounds()
+
+        errors = self.autofocus_controller.refresh_bounds_validation()
+
+        expected = (
+            "The requested coarse scan (-250 to 250 µm) exceeds the focus-stage "
+            "limits (0 to 1000 µm)."
+        )
+        assert errors == [expected]
+        assert self.autofocus_controller.view.bounds_warning_var.get() == expected
+        coarse_range = self.autofocus_controller.widgets["coarse_range"].widget
+        fine_range = self.autofocus_controller.widgets["fine_range"].widget
+        assert str(coarse_range.cget("foreground")) == get_theme_color(
+            "danger", "red"
+        )
+        assert str(fine_range.cget("foreground")) == get_theme_color(
+            "text", "black"
+        )
+
+        self.autofocus_controller.parent_controller.configuration["experiment"][
+            "StageParameters"
+        ]["f"] = 500
+        assert self.autofocus_controller.refresh_bounds_validation() == []
+        assert self.autofocus_controller.view.bounds_warning_var.get() == ""
+        assert str(coarse_range.cget("foreground")) == get_theme_color(
+            "text", "black"
+        )
+
+    def test_refresh_bounds_validation_checks_fine_only(self):
+        settings = self.configure_focus_bounds()
+        settings.update(
+            {
+                "coarse_selected": False,
+                "fine_selected": True,
+                "fine_range": 50,
+                "fine_step_size": 5,
+            }
+        )
+        self.autofocus_controller.view.setting_vars["coarse_selected"].set(False)
+        self.autofocus_controller.view.setting_vars["fine_selected"].set(True)
+
+        errors = self.autofocus_controller.refresh_bounds_validation()
+
+        assert errors == [
+            "The requested fine scan (-25 to 25 µm) exceeds the focus-stage "
+            "limits (0 to 1000 µm)."
+        ]
+
+    def test_refresh_bounds_validation_does_not_guess_combined_fine_center(self):
+        settings = self.configure_focus_bounds()
+        self.autofocus_controller.parent_controller.configuration["experiment"][
+            "StageParameters"
+        ]["f"] = 500
+        settings.update(
+            {
+                "coarse_selected": True,
+                "coarse_range": 100,
+                "coarse_step_size": 10,
+                "fine_selected": True,
+                "fine_range": 5000,
+                "fine_step_size": 50,
+            }
+        )
+        for key in (
+            "coarse_selected",
+            "coarse_range",
+            "coarse_step_size",
+            "fine_selected",
+            "fine_range",
+            "fine_step_size",
+        ):
+            self.autofocus_controller.view.setting_vars[key].set(settings[key])
+
+        assert self.autofocus_controller.refresh_bounds_validation() == []
+
+    def test_refresh_bounds_validation_ignores_disabled_limits(self):
+        self.configure_focus_bounds(enabled=False)
+
+        assert self.autofocus_controller.refresh_bounds_validation() == []
+
+    def test_start_autofocus_blocks_invalid_bounds_with_final_dialog(self):
+        self.configure_focus_bounds()
+        parent = self.autofocus_controller.parent_controller
+
+        with patch.object(parent, "execute") as execute, patch(
+            "navigate.controller.sub_controllers.autofocus.messagebox.showerror"
+        ) as showerror:
+            self.autofocus_controller.start_autofocus()
+
+        execute.assert_not_called()
+        showerror.assert_called_once_with(
+            title="Navigate",
+            message=(
+                "The requested coarse scan (-250 to 250 µm) exceeds the "
+                "focus-stage limits (0 to 1000 µm)."
+            ),
+        )
 
     def test_stop_acquisition_button_matches_start_button(self):
         """The popup exposes an equally emphasized acquisition stop control."""

--- a/test/controller/test_controller.py
+++ b/test/controller/test_controller.py
@@ -613,13 +613,23 @@ def test_execute_update_setting(controller):
 def test_execute_stage_limits(controller):
     controller.threads_pool.createThread = MagicMock()
     controller.channels_tab_controller.update_stack_position_limits = MagicMock()
-    for stage_limits in [True, False]:
-        controller.threads_pool.createThread.reset_mock()
-        controller.channels_tab_controller.update_stack_position_limits.reset_mock()
-        controller.execute("stage_limits", stage_limits)
-        assert controller.stage_controller.stage_limits == stage_limits
-        controller.channels_tab_controller.update_stack_position_limits.assert_called_once()
-        assert controller.threads_pool.createThread.called is True
+    controller.af_popup_controller = MagicMock()
+    try:
+        for stage_limits in [True, False]:
+            controller.threads_pool.createThread.reset_mock()
+            controller.channels_tab_controller.update_stack_position_limits.reset_mock()
+            controller.af_popup_controller.refresh_bounds_validation.reset_mock()
+            controller.execute("stage_limits", stage_limits)
+            assert controller.stage_controller.stage_limits == stage_limits
+            assert (
+                controller.configuration["experiment"]["StageParameters"]["limits"]
+                == stage_limits
+            )
+            controller.channels_tab_controller.update_stack_position_limits.assert_called_once()
+            controller.af_popup_controller.refresh_bounds_validation.assert_called_once()
+            assert controller.threads_pool.createThread.called is True
+    finally:
+        del controller.af_popup_controller
 
     assert True
 
@@ -628,14 +638,36 @@ def test_execute_update_stage_limits_refreshes_stack_position_limits(controller)
     controller.threads_pool.createThread = MagicMock()
     controller.stage_controller.initialize = MagicMock()
     controller.channels_tab_controller.update_stack_position_limits = MagicMock()
+    controller.af_popup_controller = MagicMock()
 
-    controller.execute(
-        "update_stage_limits", controller.configuration_controller.microscope_name
-    )
+    try:
+        controller.execute(
+            "update_stage_limits", controller.configuration_controller.microscope_name
+        )
 
-    controller.stage_controller.initialize.assert_called_once()
-    controller.channels_tab_controller.update_stack_position_limits.assert_called_once()
-    assert controller.threads_pool.createThread.called is True
+        controller.stage_controller.initialize.assert_called_once()
+        controller.channels_tab_controller.update_stack_position_limits.assert_called_once()
+        controller.af_popup_controller.refresh_bounds_validation.assert_called_once()
+        assert controller.threads_pool.createThread.called is True
+    finally:
+        del controller.af_popup_controller
+
+
+def test_update_stage_controller_silent_refreshes_autofocus_bounds(controller):
+    original_set_position_silent = controller.stage_controller.set_position_silent
+    controller.stage_controller.set_position_silent = MagicMock()
+    controller.af_popup_controller = MagicMock()
+
+    try:
+        controller.update_stage_controller_silent({"f_pos": 123.4})
+
+        controller.stage_controller.set_position_silent.assert_called_once_with(
+            {"f": 123.4}
+        )
+        controller.af_popup_controller.refresh_bounds_validation.assert_called_once()
+    finally:
+        controller.stage_controller.set_position_silent = original_set_position_silent
+        del controller.af_popup_controller
 
 
 def test_execute_autofocus(controller):

--- a/test/controller/test_controller.py
+++ b/test/controller/test_controller.py
@@ -781,6 +781,41 @@ def test_live_autofocus_completion_reenables_start_button(controller):
             controller.af_popup_controller.close_popup()
 
 
+def test_progress_transport_cannot_starve_reliable_autofocus_events(controller):
+    original_event_queue = controller.event_queue
+    original_progress_queue = controller.autofocus_progress_queue
+    original_event_pump_running = controller._event_pump_running
+    progress_handler = MagicMock()
+    final_handler = MagicMock()
+    controller.event_listeners["autofocus_progress"] = progress_handler
+    controller.event_listeners["autofocus"] = final_handler
+
+    try:
+        controller.autofocus_progress_queue = Queue(maxsize=1)
+        controller.autofocus_progress_queue.put([[1.0, 2.0]])
+        controller.event_queue = Queue()
+        controller.event_queue.put(("autofocus", [[[1.0, 2.0]], False, True]))
+        controller.event_queue.put(("warning", "Autofocus bounds warning"))
+        controller._event_pump_running = True
+
+        with patch(
+            "navigate.controller.controller.messagebox.showwarning"
+        ) as showwarning:
+            controller.update_event()
+
+        progress_handler.assert_called_once_with([[1.0, 2.0]])
+        final_handler.assert_called_once_with([[[1.0, 2.0]], False, True])
+        showwarning.assert_called_once_with(
+            title="Navigate", message="Autofocus bounds warning"
+        )
+    finally:
+        controller.event_queue = original_event_queue
+        controller.autofocus_progress_queue = original_progress_queue
+        controller._event_pump_running = original_event_pump_running
+        controller.event_listeners.pop("autofocus_progress", None)
+        controller.event_listeners.pop("autofocus", None)
+
+
 def test_execute_eliminate_tiles(controller):
     controller.threads_pool.createThread = MagicMock()
 

--- a/test/model/features/test_autofocus.py
+++ b/test/model/features/test_autofocus.py
@@ -527,7 +527,7 @@ class TestAutofocusClass(unittest.TestCase):
 
     def test_in_func_data_publishes_defensive_progress_snapshots(self):
         model = self.autofocus.model
-        model.event_queue = MagicMock()
+        model.autofocus_progress_queue = MagicMock()
         model.logger = MagicMock()
         self.autofocus.pre_func_data()
         self.autofocus.total_frame_num = 2
@@ -542,26 +542,25 @@ class TestAutofocusClass(unittest.TestCase):
 
         progress_calls = [
             call
-            for call in model.event_queue.put_nowait.call_args_list
-            if call.args[0][0] == "autofocus_progress"
+            for call in model.autofocus_progress_queue.put_nowait.call_args_list
         ]
         self.assertEqual(
             progress_calls,
             [
-                unittest.mock.call(("autofocus_progress", [[10.0, 1.0]])),
-                unittest.mock.call(
-                    ("autofocus_progress", [[10.0, 1.0], [20.0, 2.0]])
-                ),
+                unittest.mock.call([[10.0, 1.0]]),
+                unittest.mock.call([[10.0, 1.0], [20.0, 2.0]]),
             ],
         )
 
         self.autofocus.plot_data[0][1] = 999.0
-        self.assertEqual(progress_calls[0].args[0][1], [[10.0, 1.0]])
+        self.assertEqual(progress_calls[0].args[0], [[10.0, 1.0]])
 
-    def test_full_progress_queue_does_not_interrupt_metric_processing(self):
+    def test_full_progress_queue_replaces_stale_snapshot_without_blocking_events(self):
         model = self.autofocus.model
         model.event_queue = MagicMock()
-        model.event_queue.put_nowait.side_effect = Full
+        model.autofocus_progress_queue = MagicMock()
+        model.autofocus_progress_queue.put_nowait.side_effect = [Full, None]
+        model.autofocus_progress_queue.get_nowait.return_value = [[0.0, 0.0]]
         model.logger = MagicMock()
         self.autofocus.pre_func_data()
         self.autofocus.total_frame_num = 2
@@ -574,9 +573,15 @@ class TestAutofocusClass(unittest.TestCase):
             self.autofocus.in_func_data([0])
 
         self.assertEqual(self.autofocus.plot_data, [[10.0, 1.0]])
-        model.event_queue.put_nowait.assert_called_once_with(
-            ("autofocus_progress", [[10.0, 1.0]])
+        model.autofocus_progress_queue.get_nowait.assert_called_once_with()
+        self.assertEqual(
+            model.autofocus_progress_queue.put_nowait.call_args_list,
+            [
+                unittest.mock.call([[10.0, 1.0]]),
+                unittest.mock.call([[10.0, 1.0]]),
+            ],
         )
+        model.event_queue.put_nowait.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/test/model/features/test_autofocus.py
+++ b/test/model/features/test_autofocus.py
@@ -465,6 +465,39 @@ class TestAutofocusClass(unittest.TestCase):
             )
         )
 
+    def test_in_func_data_publishes_defensive_progress_snapshots(self):
+        model = self.autofocus.model
+        model.event_queue = MagicMock()
+        model.logger = MagicMock()
+        self.autofocus.pre_func_data()
+        self.autofocus.total_frame_num = 2
+        self.autofocus.autofocus_frame_queue.put((0, 2, 10.0))
+        self.autofocus.autofocus_frame_queue.put((1, 1, 20.0))
+
+        with patch(
+            "navigate.model.features.autofocus.fast_normalized_dct_shannon_entropy",
+            side_effect=(np.array([1.0]), np.array([2.0])),
+        ):
+            self.autofocus.in_func_data([0, 1])
+
+        progress_calls = [
+            call
+            for call in model.event_queue.put.call_args_list
+            if call.args[0][0] == "autofocus_progress"
+        ]
+        self.assertEqual(
+            progress_calls,
+            [
+                unittest.mock.call(("autofocus_progress", [[10.0, 1.0]])),
+                unittest.mock.call(
+                    ("autofocus_progress", [[10.0, 1.0], [20.0, 2.0]])
+                ),
+            ],
+        )
+
+        self.autofocus.plot_data[0][1] = 999.0
+        self.assertEqual(progress_calls[0].args[0][1], [[10.0, 1.0]])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/model/features/test_autofocus.py
+++ b/test/model/features/test_autofocus.py
@@ -31,7 +31,7 @@
 
 # Standard library imports
 import unittest
-from queue import Empty
+from queue import Empty, Full
 from unittest.mock import MagicMock, patch
 
 # Third party imports
@@ -127,6 +127,17 @@ class TestAutofocusScanPlanning(unittest.TestCase):
             autofocus_bounds_error("coarse", (0, 50, 100), 0, 100, "f")
         )
 
+    def test_autofocus_bounds_error_preserves_near_boundary_violation(self):
+        error = autofocus_bounds_error(
+            "fine", (999.9, 1000.0001), 0, 1000, "f"
+        )
+
+        self.assertEqual(
+            error,
+            "The requested fine scan (999.9 to 1000.0001 µm) exceeds the "
+            "focus-stage limits (0 to 1000 µm).",
+        )
+
 
 class TestAutofocusClass(unittest.TestCase):
     def setUp(self):
@@ -161,7 +172,10 @@ class TestAutofocusClass(unittest.TestCase):
         self.autofocus.model.configuration["experiment"]["AutoFocusParameters"][
             "Mesoscale"
         ]["stage"]["f"]["coarse_selected"] = True
-        frames = self.autofocus.get_autofocus_frame_num()
+        autofocus = Autofocus(
+            model=self.autofocus.model, device="stage", device_ref="f"
+        )
+        frames = autofocus.get_autofocus_frame_num()
         self.assertEqual(frames, 5)  # Expected number of frames
 
         # Only Fine Selected
@@ -171,7 +185,10 @@ class TestAutofocusClass(unittest.TestCase):
         self.autofocus.model.configuration["experiment"]["AutoFocusParameters"][
             "Mesoscale"
         ]["stage"]["f"]["coarse_selected"] = False
-        frames = self.autofocus.get_autofocus_frame_num()
+        autofocus = Autofocus(
+            model=self.autofocus.model, device="stage", device_ref="f"
+        )
+        frames = autofocus.get_autofocus_frame_num()
         self.assertEqual(frames, 6)  # Expected number of frames
 
     def test_get_steps(self):
@@ -287,6 +304,35 @@ class TestAutofocusClass(unittest.TestCase):
         self.autofocus.model.move_stage.assert_not_called()
         self.assertTrue(self.autofocus.autofocus_frame_queue.empty())
 
+    def test_combined_scan_uses_frozen_fine_settings(self):
+        self.configure_stage_bounds(minimum=-1000, maximum=1000)
+        self.set_scan_settings(
+            coarse_selected=True,
+            coarse_range=0,
+            coarse_step_size=5,
+            fine_selected=True,
+            fine_range=20,
+            fine_step_size=5,
+            focus_position=100,
+        )
+        model = self.autofocus.model
+        model.active_microscope.prepare_next_channel = MagicMock()
+        model.stop_acquisition = False
+        model.move_stage = MagicMock(return_value=True)
+        model.logger = MagicMock()
+        self.autofocus.pre_func_signal()
+        self.autofocus.signal_id = self.autofocus.coarse_steps
+        self.autofocus.autofocus_pos_queue.put(100)
+        model.configuration["experiment"]["AutoFocusParameters"]["Mesoscale"][
+            "stage"
+        ]["f"]["fine_range"] = 0
+
+        self.autofocus.in_func_signal()
+
+        model.move_stage.assert_called_once_with(
+            {"f_abs": 90}, wait_until_done=True
+        )
+
     def test_failed_stage_move_does_not_queue_measurement(self):
         self.autofocus.model.logger = MagicMock()
         self.autofocus.model.move_stage = MagicMock(return_value=False)
@@ -397,12 +443,26 @@ class TestAutofocusClass(unittest.TestCase):
         with patch(
             "navigate.model.features.autofocus.load_features",
             return_value=(MagicMock(), MagicMock()),
-        ), patch("navigate.model.features.autofocus.threading.Thread") as thread:
+        ) as load_features_mock, patch(
+            "navigate.model.features.autofocus.threading.Thread"
+        ) as thread:
             autofocus.run()
 
         model.active_microscope.prepare_channel.assert_not_called()
         model.active_microscope.prepare_next_channel.assert_not_called()
         self.assertEqual(thread.return_value.start.call_count, 2)
+        feature_args = load_features_mock.call_args.args[1][0]["args"]
+        self.assertEqual(
+            feature_args[-1],
+            {
+                "coarse_selected": True,
+                "coarse_range": 500.0,
+                "coarse_step_size": 50.0,
+                "fine_selected": True,
+                "fine_range": 50.0,
+                "fine_step_size": 5.0,
+            },
+        )
 
     def test_pre_func_signal_prepares_requested_channel(self):
         model = DummyModel()
@@ -482,7 +542,7 @@ class TestAutofocusClass(unittest.TestCase):
 
         progress_calls = [
             call
-            for call in model.event_queue.put.call_args_list
+            for call in model.event_queue.put_nowait.call_args_list
             if call.args[0][0] == "autofocus_progress"
         ]
         self.assertEqual(
@@ -497,6 +557,26 @@ class TestAutofocusClass(unittest.TestCase):
 
         self.autofocus.plot_data[0][1] = 999.0
         self.assertEqual(progress_calls[0].args[0][1], [[10.0, 1.0]])
+
+    def test_full_progress_queue_does_not_interrupt_metric_processing(self):
+        model = self.autofocus.model
+        model.event_queue = MagicMock()
+        model.event_queue.put_nowait.side_effect = Full
+        model.logger = MagicMock()
+        self.autofocus.pre_func_data()
+        self.autofocus.total_frame_num = 2
+        self.autofocus.autofocus_frame_queue.put((0, 2, 10.0))
+
+        with patch(
+            "navigate.model.features.autofocus.fast_normalized_dct_shannon_entropy",
+            return_value=np.array([1.0]),
+        ):
+            self.autofocus.in_func_data([0])
+
+        self.assertEqual(self.autofocus.plot_data, [[10.0, 1.0]])
+        model.event_queue.put_nowait.assert_called_once_with(
+            ("autofocus_progress", [[10.0, 1.0]])
+        )
 
 
 if __name__ == "__main__":

--- a/test/model/features/test_autofocus.py
+++ b/test/model/features/test_autofocus.py
@@ -123,14 +123,10 @@ class TestAutofocusScanPlanning(unittest.TestCase):
         )
 
     def test_autofocus_bounds_error_accepts_positions_at_limits(self):
-        self.assertIsNone(
-            autofocus_bounds_error("coarse", (0, 50, 100), 0, 100, "f")
-        )
+        self.assertIsNone(autofocus_bounds_error("coarse", (0, 50, 100), 0, 100, "f"))
 
     def test_autofocus_bounds_error_preserves_near_boundary_violation(self):
-        error = autofocus_bounds_error(
-            "fine", (999.9, 1000.0001), 0, 1000, "f"
-        )
+        error = autofocus_bounds_error("fine", (999.9, 1000.0001), 0, 1000, "f")
 
         self.assertEqual(
             error,
@@ -261,6 +257,45 @@ class TestAutofocusClass(unittest.TestCase):
 
         self.assertIsNone(self.autofocus.get_initial_scan_bounds_error())
 
+    def test_run_rejects_when_no_valid_scan_mode_is_selected(self):
+        self.set_scan_settings(
+            coarse_selected=True,
+            coarse_range=0,
+            fine_selected=True,
+            fine_range=0,
+        )
+        model = self.autofocus.model
+        model.prepare_acquisition = MagicMock()
+        model.event_queue = MagicMock()
+        model.show_img_pipe = MagicMock()
+        model.is_acquiring = True
+
+        self.autofocus.run()
+
+        model.prepare_acquisition.assert_not_called()
+        model.event_queue.put.assert_called_once_with(
+            (
+                "warning",
+                "Coarse/Fine settings error!\n\n"
+                "Select at least one mode: Coarse or Fine.\n"
+                "Please ensure the range and step size are greater than zero.",
+            )
+        )
+        model.show_img_pipe.send.assert_called_once_with("stop")
+        self.assertFalse(model.is_acquiring)
+
+    def test_negative_scan_settings_are_normalized_before_frame_counting(self):
+        self.set_scan_settings(
+            coarse_selected=True,
+            coarse_range=-10,
+            coarse_step_size=-2,
+            fine_selected=False,
+        )
+
+        self.assertEqual(self.autofocus.get_autofocus_frame_num(), 6)
+        self.assertEqual(self.autofocus.coarse_range, 10)
+        self.assertEqual(self.autofocus.coarse_step_size, 2)
+
     def test_fine_only_scan_is_validated_at_current_position(self):
         self.configure_stage_bounds()
         self.set_scan_settings(
@@ -281,7 +316,7 @@ class TestAutofocusClass(unittest.TestCase):
         self.configure_stage_bounds()
         self.set_scan_settings(
             coarse_selected=True,
-            coarse_range=0,
+            coarse_range=5,
             coarse_step_size=5,
             fine_selected=True,
             fine_range=50,
@@ -308,7 +343,7 @@ class TestAutofocusClass(unittest.TestCase):
         self.configure_stage_bounds(minimum=-1000, maximum=1000)
         self.set_scan_settings(
             coarse_selected=True,
-            coarse_range=0,
+            coarse_range=5,
             coarse_step_size=5,
             fine_selected=True,
             fine_range=20,
@@ -323,15 +358,13 @@ class TestAutofocusClass(unittest.TestCase):
         self.autofocus.pre_func_signal()
         self.autofocus.signal_id = self.autofocus.coarse_steps
         self.autofocus.autofocus_pos_queue.put(100)
-        model.configuration["experiment"]["AutoFocusParameters"]["Mesoscale"][
-            "stage"
-        ]["f"]["fine_range"] = 0
+        model.configuration["experiment"]["AutoFocusParameters"]["Mesoscale"]["stage"][
+            "f"
+        ]["fine_range"] = 0
 
         self.autofocus.in_func_signal()
 
-        model.move_stage.assert_called_once_with(
-            {"f_abs": 90}, wait_until_done=True
-        )
+        model.move_stage.assert_called_once_with({"f_abs": 90}, wait_until_done=True)
 
     def test_failed_stage_move_does_not_queue_measurement(self):
         self.autofocus.model.logger = MagicMock()
@@ -440,12 +473,13 @@ class TestAutofocusClass(unittest.TestCase):
             target_channel="channel_2",
         )
 
-        with patch(
-            "navigate.model.features.autofocus.load_features",
-            return_value=(MagicMock(), MagicMock()),
-        ) as load_features_mock, patch(
-            "navigate.model.features.autofocus.threading.Thread"
-        ) as thread:
+        with (
+            patch(
+                "navigate.model.features.autofocus.load_features",
+                return_value=(MagicMock(), MagicMock()),
+            ) as load_features_mock,
+            patch("navigate.model.features.autofocus.threading.Thread") as thread,
+        ):
             autofocus.run()
 
         model.active_microscope.prepare_channel.assert_not_called()
@@ -541,8 +575,7 @@ class TestAutofocusClass(unittest.TestCase):
             self.autofocus.in_func_data([0, 1])
 
         progress_calls = [
-            call
-            for call in model.autofocus_progress_queue.put_nowait.call_args_list
+            call for call in model.autofocus_progress_queue.put_nowait.call_args_list
         ]
         self.assertEqual(
             progress_calls,

--- a/test/model/features/test_autofocus.py
+++ b/test/model/features/test_autofocus.py
@@ -40,6 +40,9 @@ import numpy as np
 # Local imports
 from navigate.model.features.autofocus import power_tent
 from navigate.model.features.autofocus import Autofocus
+from navigate.model.features.autofocus import autofocus_bounds_error
+from navigate.model.features.autofocus import plan_autofocus_positions
+from navigate.model.utils.exceptions import UserVisibleException
 from test.model.dummy import DummyModel
 
 
@@ -77,6 +80,52 @@ class TestPowerTentFunction(unittest.TestCase):
         # Test at x = x_offset + 1, should be y_offset
         result = power_tent(x_offset + 1, x_offset, y_offset, amplitude, sigma, alpha)
         self.assertAlmostEqual(result, y_offset, places=6)
+
+
+class TestAutofocusScanPlanning(unittest.TestCase):
+    def test_plan_autofocus_positions_with_odd_frame_count(self):
+        self.assertEqual(
+            plan_autofocus_positions(0, 500, 50),
+            tuple(range(-250, 251, 50)),
+        )
+
+    def test_plan_autofocus_positions_with_even_frame_count(self):
+        self.assertEqual(
+            plan_autofocus_positions(0, 10, 2),
+            (-6, -4, -2, 0, 2, 4),
+        )
+
+    def test_plan_autofocus_positions_preserves_center_and_partial_range(self):
+        self.assertEqual(
+            plan_autofocus_positions(12.5, 5, 2),
+            (10.5, 12.5, 14.5),
+        )
+
+    def test_autofocus_bounds_error_reports_each_violation(self):
+        lower = autofocus_bounds_error("coarse", (-10, 0, 10), 0, 100, "f")
+        upper = autofocus_bounds_error("fine", (90, 100, 110), 0, 100, "f")
+        both = autofocus_bounds_error("coarse", (-10, 50, 110), 0, 100, "f")
+
+        self.assertEqual(
+            lower,
+            "The requested coarse scan (-10 to 10 µm) exceeds the focus-stage "
+            "limits (0 to 100 µm).",
+        )
+        self.assertEqual(
+            upper,
+            "The requested fine scan (90 to 110 µm) exceeds the focus-stage "
+            "limits (0 to 100 µm).",
+        )
+        self.assertEqual(
+            both,
+            "The requested coarse scan (-10 to 110 µm) exceeds the focus-stage "
+            "limits (0 to 100 µm).",
+        )
+
+    def test_autofocus_bounds_error_accepts_positions_at_limits(self):
+        self.assertIsNone(
+            autofocus_bounds_error("coarse", (0, 50, 100), 0, 100, "f")
+        )
 
 
 class TestAutofocusClass(unittest.TestCase):
@@ -130,6 +179,144 @@ class TestAutofocusClass(unittest.TestCase):
         steps, pos_offset = self.autofocus.get_steps(10.0, 2.0)
         self.assertEqual(steps, 6)  # Expected number of steps
         self.assertEqual(pos_offset, 8.0)  # Expected position offset
+
+    def configure_stage_bounds(self, minimum=0, maximum=1000, enabled=True):
+        stage = MagicMock()
+        stage.stage_limits = enabled
+        stage.f_min = minimum
+        stage.f_max = maximum
+        self.autofocus.model.active_microscope.stages = {"f": stage}
+        return stage
+
+    def set_scan_settings(
+        self,
+        *,
+        coarse_selected=True,
+        coarse_range=500,
+        coarse_step_size=50,
+        fine_selected=False,
+        fine_range=50,
+        fine_step_size=5,
+        focus_position=0,
+    ):
+        settings = self.autofocus.model.configuration["experiment"][
+            "AutoFocusParameters"
+        ]["Mesoscale"]["stage"]["f"]
+        settings.update(
+            {
+                "coarse_selected": coarse_selected,
+                "coarse_range": coarse_range,
+                "coarse_step_size": coarse_step_size,
+                "fine_selected": fine_selected,
+                "fine_range": fine_range,
+                "fine_step_size": fine_step_size,
+            }
+        )
+        self.autofocus.model.configuration["experiment"]["StageParameters"][
+            "f"
+        ] = focus_position
+
+    def test_run_rejects_invalid_coarse_scan_before_preparing_acquisition(self):
+        self.configure_stage_bounds()
+        self.set_scan_settings()
+        model = self.autofocus.model
+        model.prepare_acquisition = MagicMock()
+        model.event_queue = MagicMock()
+        model.show_img_pipe = MagicMock()
+        model.is_acquiring = True
+
+        self.autofocus.run()
+
+        model.prepare_acquisition.assert_not_called()
+        model.event_queue.put.assert_called_once_with(
+            (
+                "warning",
+                "The requested coarse scan (-250 to 250 µm) exceeds the "
+                "focus-stage limits (0 to 1000 µm).",
+            )
+        )
+        model.show_img_pipe.send.assert_called_once_with("stop")
+        self.assertFalse(model.is_acquiring)
+
+    def test_initial_scan_bounds_ignore_disabled_soft_limits(self):
+        self.configure_stage_bounds(enabled=False)
+        self.set_scan_settings()
+
+        self.assertIsNone(self.autofocus.get_initial_scan_bounds_error())
+
+    def test_fine_only_scan_is_validated_at_current_position(self):
+        self.configure_stage_bounds()
+        self.set_scan_settings(
+            coarse_selected=False,
+            fine_selected=True,
+            fine_range=50,
+            fine_step_size=5,
+            focus_position=995,
+        )
+
+        self.assertEqual(
+            self.autofocus.get_initial_scan_bounds_error(),
+            "The requested fine scan (970 to 1020 µm) exceeds the focus-stage "
+            "limits (0 to 1000 µm).",
+        )
+
+    def test_combined_fine_scan_is_validated_after_coarse_result(self):
+        self.configure_stage_bounds()
+        self.set_scan_settings(
+            coarse_selected=True,
+            coarse_range=0,
+            coarse_step_size=5,
+            fine_selected=True,
+            fine_range=50,
+            fine_step_size=5,
+            focus_position=500,
+        )
+        self.autofocus.model.active_microscope.prepare_next_channel = MagicMock()
+        self.autofocus.pre_func_signal()
+        self.autofocus.signal_id = self.autofocus.coarse_steps
+        self.autofocus.model.stop_acquisition = False
+        self.autofocus.autofocus_pos_queue.put(995)
+        self.autofocus.model.move_stage = MagicMock(return_value=True)
+
+        with self.assertRaisesRegex(
+            UserVisibleException,
+            r"requested fine scan \(970 to 1020 µm\)",
+        ):
+            self.autofocus.in_func_signal()
+
+        self.autofocus.model.move_stage.assert_not_called()
+        self.assertTrue(self.autofocus.autofocus_frame_queue.empty())
+
+    def test_failed_stage_move_does_not_queue_measurement(self):
+        self.autofocus.model.logger = MagicMock()
+        self.autofocus.model.move_stage = MagicMock(return_value=False)
+        self.autofocus.coarse_positions = (10,)
+        self.autofocus.coarse_steps = 1
+        self.autofocus.signal_id = 0
+        self.autofocus.total_frame_num = 1
+
+        with self.assertRaisesRegex(
+            UserVisibleException,
+            r"could not move the focus stage to 10 µm",
+        ):
+            self.autofocus.in_func_signal()
+
+        self.assertTrue(self.autofocus.autofocus_frame_queue.empty())
+
+    def test_successful_stage_move_queues_measurement(self):
+        self.autofocus.model.logger = MagicMock()
+        self.autofocus.model.move_stage = MagicMock(return_value=True)
+        self.autofocus.coarse_positions = (10,)
+        self.autofocus.coarse_steps = 1
+        self.autofocus.signal_id = 0
+        self.autofocus.total_frame_num = 1
+
+        self.autofocus.in_func_signal()
+
+        self.assertEqual(
+            self.autofocus.autofocus_frame_queue.get_nowait(),
+            (self.autofocus.model.frame_id, 1, 10),
+        )
 
     def test_wait_for_focus_position_stops_after_cancellation(self):
         """A stop request releases an autofocus focus-position handoff."""


### PR DESCRIPTION
## Summary

- reject autofocus trajectories that exceed enabled focus-stage limits without shifting, clamping, or truncating requested positions
- provide immediate bounds feedback in the autofocus popup and refresh it when focus position or stage limits change
- plot autofocus measurements incrementally using a persistent Matplotlib artist, Tk-thread coalescing, and blitting with a full-draw fallback
- keep replaceable progress traffic separate from reliable warnings, final plots, and calibration-completion events
- preserve defocus-calibration bookkeeping when the autofocus popup is closed during a sequence

## Root cause

Autofocus frame planning and execution did not share an authoritative bounds check, so an out-of-range trajectory could begin and then stop after the first unsuccessful move. The popup also had no continuously refreshed indication that the requested path was unsafe. Plotting waited for the final autofocus event, and early progress delivery initially shared capacity and popup lifetime with reliable completion handling.

## User impact

The requested scan geometry is now treated as an exact safety contract. Users see an inline red warning before starting, receive a final blocking dialog if needed, and can immediately see when moving the focus stage or changing limits makes the scan valid. During a valid autofocus run, the graph updates as measurements arrive while acquisition remains nonblocking.

## Implementation

- centralize exact coarse/fine position planning and reuse it for frame counts, controller preflight, and model execution
- validate the initial scan before acquisition preparation and validate a combined fine scan against the measured coarse result
- abort failed stage moves before queueing a measurement
- freeze scan settings at dispatch so mid-run edits cannot alter the active trajectory
- add a one-slot latest-progress multiprocessing queue drained by the existing Tk event pump
- move autofocus completion and defocus-calibration processing into a persistent main-controller-owned helper
- reuse the existing validated spinbox styling, stage update hooks, controller event pump, and histogram blitting pattern

## Validation

- 122 focused autofocus, popup, stage-limit, histogram, and main-controller tests passed
- model regression suite passed
- Ruff lint passed on all changed Python files
- `git diff --check origin/develop...HEAD` passed
- independent code review reported no Critical, Important, or Minor findings

Closes #315
