### PR TITLE
Move camera delay to waveform constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,6 +299,5 @@ test.xml
 /docs/source/05_reference/_autosummary
 /docs/source/05_reference/_autosummary
 codex.md
-AGENTS.md
 uv.lock
 .worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -299,5 +299,6 @@ test.xml
 /docs/source/05_reference/_autosummary
 /docs/source/05_reference/_autosummary
 codex.md
+AGENTS.md
 uv.lock
 .worktrees/

--- a/docs/source/02_user_guide/01_supported_hardware/camera.rst
+++ b/docs/source/02_user_guide/01_supported_hardware/camera.rst
@@ -7,6 +7,11 @@ Cameras
 The software supports camera-based acquisition. It can run both normal and rolling
 shutter modes of contemporary scientific CMOS cameras.
 
+Set the camera trigger delay in
+:menuselection:`Microscope Configuration --> Waveform Parameters`. The camera
+configuration examples below describe camera hardware and acquisition settings;
+they do not set waveform timing.
+
 Driver Installation
 -------------------
 
@@ -46,7 +51,6 @@ More information on the Daheng MER2-1220-32U3C camera can be found on the
                 type: daheng.Daheng
                 serial_number: "123456"
               defect_correct_mode: 2.0
-              delay: 1.0  #ms
               settle_down: 0.1 #ms
               flip_x: False
               flip_y: False
@@ -87,7 +91,6 @@ ORCA-Flash4.0 V3
                 serial_number: 111
                 camera_connection:
               defect_correct_mode: 2.0
-              delay: 1.0  #ms
               settle_down: 0.1 #ms
               flip_x: False
               flip_y: False
@@ -117,7 +120,6 @@ ORCA-Fusion
                 serial_number: 111
                 camera_connection:
               defect_correct_mode: 2.0
-              delay: 1.0  #ms
               settle_down: 0.1 #ms
               flip_x: False
               flip_y: False
@@ -147,7 +149,6 @@ ORCA-Lightning
                 serial_number: 111
                 camera_connection:
               defect_correct_mode: 2.0
-              delay: 1.0  #ms
               settle_down: 0.1 #ms
               flip_x: False
               flip_y: False
@@ -178,7 +179,6 @@ ORCA-Fire
                 serial_number: 111
                 camera_connection:
               defect_correct_mode: 2.0
-              delay: 1.0  #ms
               settle_down: 0.1 #ms
               flip_x: False
               flip_y: False
@@ -215,10 +215,10 @@ Iris 15
                 serial_number: 111
                 camera_connection: PMPCIECam00
               defect_correct_mode: 2.0
-              delay: 1.0  #ms
               settle_down: 0.1 #ms
               flip_x: False
               flip_y: False
+
 |
 
 -----------------
@@ -241,7 +241,6 @@ MU196MR-ON
                 type: ximea.MU196XR
                 serial_number: 111
               defect_correct_mode: 2.0
-              delay: 1.0  #ms
               settle_down: 0.1 #ms
               flip_x: False
               flip_y: False
@@ -264,6 +263,7 @@ MU196MR-ON
               y_pixels: 3840
               y_pixels_min: 2
               y_pixels_step: 2
+
 |
 
 ------------------
@@ -288,7 +288,6 @@ the synthetic camera class must be used.
                 serial_number: 111
                 camera_connection:
               defect_correct_mode: 2.0
-              delay: 1.0  #ms
               settle_down: 0.1 #ms
               flip_x: False
               flip_y: False

--- a/docs/source/02_user_guide/03_user_interface_walkthrough/06_popups_and_tools.rst
+++ b/docs/source/02_user_guide/03_user_interface_walkthrough/06_popups_and_tools.rst
@@ -91,7 +91,11 @@ Waveform Parameters
    :align: center
    :alt: Waveform Parameter Settings popup.
 
-Use this popup to configure waveform amplitudes, offsets, timing, and smoothing used by :ref:`Waveform Settings <ui_waveform_settings>`.
+Use this popup to configure waveform amplitudes, offsets, timing, and smoothing
+used by :ref:`Waveform Settings <ui_waveform_settings>`. The
+:guilabel:`Camera Delay` value is measured in milliseconds and is saved in
+``waveform_constants.yml``. It is shared by all microscope modes in the active
+configuration.
 
 Advanced Galvo Setting
 ======================

--- a/docs/source/02_user_guide/04_microscope_setup/01_software_configuration/software_configuration.rst
+++ b/docs/source/02_user_guide/04_microscope_setup/01_software_configuration/software_configuration.rst
@@ -339,6 +339,18 @@ The ``waveform_constants.yml`` file stores waveform parameters exposed through
 Users normally do not need to edit this file manually. **navigate** updates it
 automatically during use and on exit.
 
+:guilabel:`Camera Delay` is the delay between the acquisition trigger and the
+camera trigger, in milliseconds. The value in ``waveform_constants.yml`` is
+used during acquisition and is shared by all microscope modes in the active
+configuration. Loading another waveform constants file updates the value used
+by the data acquisition device.
+
+For compatibility with older configurations, **navigate** initializes a missing
+or non-numeric ``camera_delay`` from the first configured microscope's legacy
+``camera.delay`` value, or its older ``camera.delay_percent`` value. If neither
+value exists, the default is 1 millisecond. After migration, set Camera Delay
+through the Waveform Parameters popup rather than adding it to a camera block.
+
 .. _configure_waveform_templates:
 
 Waveform Templates File

--- a/docs/source/05_reference/implementations/configurations/configuration_OPMv2.yaml
+++ b/docs/source/05_reference/implementations/configurations/configuration_OPMv2.yaml
@@ -32,7 +32,6 @@ microscopes:
         type: HamamatsuOrca
         serial_number: 304064
       defect_correct_mode: 2.0
-      delay: 7.5 #ms
       settle_down: 0.0 #ms
     remote_focus_device:
       hardware:

--- a/docs/source/05_reference/implementations/configurations/configuration_OPMv3.yaml
+++ b/docs/source/05_reference/implementations/configurations/configuration_OPMv3.yaml
@@ -42,7 +42,6 @@ microscopes:
         type: HamamatsuOrca
         serial_number: 001301
       defect_correct_mode: 2.0
-      delay: 10 #ms
       settle_down: 0.0 #ms
     remote_focus_device:
       hardware:
@@ -199,7 +198,6 @@ microscopes:
         type: HamamatsuOrca
         serial_number: 001301
       defect_correct_mode: 2.0
-      delay: 10 #ms
 
     remote_focus_device:
       hardware:

--- a/docs/source/05_reference/implementations/configurations/configuration_biofrontiers.yaml
+++ b/docs/source/05_reference/implementations/configurations/configuration_biofrontiers.yaml
@@ -15,7 +15,6 @@ microscopes:
         type: HamamatsuOrca
         serial_number: 000646
       defect_correct_mode: 2.0
-      delay: 10.0 #ms
       settle_down: 0.0 #ms
       flip_x: False
       flip_y: False

--- a/docs/source/05_reference/implementations/configurations/configuration_ctaslmv1.yaml
+++ b/docs/source/05_reference/implementations/configurations/configuration_ctaslmv1.yaml
@@ -19,7 +19,6 @@ microscopes:
         type: HamamatsuOrca
         serial_number: 000420
       defect_correct_mode: 2.0
-      delay: 2.0 #ms
       settle_down: 0.0 #ms
       flip_x: False
       flip_y: False

--- a/docs/source/05_reference/implementations/configurations/configuration_ctaslmv2.yaml
+++ b/docs/source/05_reference/implementations/configurations/configuration_ctaslmv2.yaml
@@ -22,7 +22,6 @@ microscopes:
       flip_x: True
       flip_y: False
       defect_correct_mode: 2.0
-      delay: 20
     remote_focus_device:
       hardware:
         type: EquipmentSolutions # NI

--- a/docs/source/05_reference/implementations/configurations/configuration_mesospimbt.yaml
+++ b/docs/source/05_reference/implementations/configurations/configuration_mesospimbt.yaml
@@ -19,7 +19,6 @@ microscopes:
         type: HamamatsuOrca
         serial_number: 003209
       defect_correct_mode: 2.0 #2.0
-      delay: 10 #ms
       settle_down: 0.0 #ms
       flip_x: True
       flip_y: False

--- a/docs/source/05_reference/implementations/configurations/configuration_multiscale.yaml
+++ b/docs/source/05_reference/implementations/configurations/configuration_multiscale.yaml
@@ -40,7 +40,6 @@ microscopes:
       trigger_polarity: 2.0  # positive pulse
       trigger_source: 2.0  # 2 = external, 3 = software.
       exposure_time: 20 # Use milliseconds throughout.
-      delay_percent: 10
       pulse_percent: 1
       line_interval: 0.000075
       display_acquisition_subsampling: 4
@@ -251,7 +250,6 @@ microscopes:
         type: HamamatsuOrca
         serial_number: 500502
       defect_correct_mode: 2.0
-      delay: 10 #ms
       settle_down: 0.0 #ms
 
     remote_focus_device:

--- a/docs/source/05_reference/implementations/configurations/configuration_spectral_tirf.yaml
+++ b/docs/source/05_reference/implementations/configurations/configuration_spectral_tirf.yaml
@@ -42,7 +42,6 @@ microscopes:
       trigger_polarity: 2.0  # positive pulse
       trigger_source: 2.0  # 2 = external, 3 = software.
       exposure_time: 20 # Use milliseconds throughout.
-      delay_percent: 10
       pulse_percent: 1
       line_interval: 0.000075
       display_acquisition_subsampling: 4

--- a/docs/source/05_reference/implementations/configurations/configuration_upright.yaml
+++ b/docs/source/05_reference/implementations/configurations/configuration_upright.yaml
@@ -23,7 +23,6 @@ microscopes:
         type: HamamatsuOrcaLightning #SyntheticCamera
         serial_number: 000035
       defect_correct_mode: 2.0
-      delay: 10 #ms
       settle_down: 0.0 #ms
     remote_focus_device:
       hardware:
@@ -207,7 +206,6 @@ microscopes:
       y_pixels: 2960.0
       pixel_size_in_microns: 4.25
       defect_correct_mode: 2.0
-      delay: 25 #8 #5.0
       settle_down: 0.0 #ms
     remote_focus_device:
       hardware:

--- a/docs/source/05_reference/implementations/configurations/configuration_voodoo.yaml
+++ b/docs/source/05_reference/implementations/configurations/configuration_voodoo.yaml
@@ -17,7 +17,6 @@ microscopes:
         type: HamamatsuOrca
         serial_number: 100803
       defect_correct_mode: 2.0
-      delay: 20 #ms
       settle_down: 0.0 #ms
 #      -
 #        hardware:

--- a/docs/source/05_reference/implementations/implementations.rst
+++ b/docs/source/05_reference/implementations/implementations.rst
@@ -8,6 +8,53 @@ As an example of the flexibility of the **navigate** software, we describe sever
 
 For more information on how to build these microscopes, as well as their performance, please refer to the publications listed in the relevant sections.
 
+Camera trigger timing is stored in ``waveform_constants.yml``, not in the
+camera blocks included below. Set :guilabel:`Camera Delay` through
+:menuselection:`Microscope Configuration --> Waveform Parameters` and validate
+it on the connected hardware. The following values are the legacy starting
+points from these example configurations; they are not automatically loaded by
+the configuration files. Camera Delay is currently shared by all microscope
+modes in an active configuration, including implementations that previously
+listed different values for different modes.
+
+.. list-table:: Legacy Camera Delay starting values
+   :header-rows: 1
+   :widths: 42 38 20
+
+   * - Configuration file
+     - Microscope mode
+     - Delay (ms)
+   * - ``configuration_voodoo.yaml``
+     - CTASLMv2
+     - 20
+   * - ``configuration_OPMv2.yaml``
+     - OPMv2
+     - 7.5
+   * - ``configuration_OPMv3.yaml``
+     - ProjectionScope and StackingScope
+     - 10
+   * - ``configuration_ctaslmv1.yaml``
+     - CTASLMv1
+     - 2
+   * - ``configuration_ctaslmv2.yaml``
+     - CTASLMv2
+     - 20
+   * - ``configuration_upright.yaml``
+     - Nanoscale / Macroscale
+     - 10 / 25
+   * - ``configuration_multiscale.yaml``
+     - Mesoscale and Nanoscale
+     - 10
+   * - ``configuration_spectral_tirf.yaml``
+     - SpectralTIRF_lt538
+     - 10
+   * - ``configuration_biofrontiers.yaml``
+     - OPM
+     - 10
+   * - ``configuration_mesospimbt.yaml``
+     - BTMesoSPIM
+     - 10
+
 ------------------
 
 ASLM

--- a/src/navigate/config/config.py
+++ b/src/navigate/config/config.py
@@ -874,15 +874,18 @@ def verify_waveform_constants(manager, configuration):
     # other_constants
     waveform_dict = configuration["waveform_constants"]
     microscope_name = configuration["configuration"]["microscopes"].keys()[0]
+    camera_config = configuration["configuration"]["microscopes"][microscope_name][
+        "camera"
+    ]
     other_constants_dict = {
         "remote_focus_settle_duration": "0",
         "percent_smoothing": "0",
         "remote_focus_delay": "0",
         "remote_focus_ramp_falling": "5",
         "camera_settle_duration": "0",
-        "camera_delay": configuration["configuration"]["microscopes"][
-            microscope_name
-        ]["camera"].get("delay", "1.0"),
+        "camera_delay": camera_config.get(
+            "delay", camera_config.get("delay_percent", "1.0")
+        ),
     }
     if (
         "other_constants" not in waveform_dict.keys()

--- a/src/navigate/config/config.py
+++ b/src/navigate/config/config.py
@@ -880,9 +880,9 @@ def verify_waveform_constants(manager, configuration):
         "remote_focus_delay": "0",
         "remote_focus_ramp_falling": "5",
         "camera_settle_duration": "0",
-        "camera_delay": configuration["configuration"]["microscopes"][microscope_name][
-            "camera"
-        ]["delay"],
+        "camera_delay": configuration["configuration"]["microscopes"][
+            microscope_name
+        ]["camera"].get("delay", "1.0"),
     }
     if (
         "other_constants" not in waveform_dict.keys()
@@ -974,8 +974,6 @@ def verify_configuration(manager, configuration):
     ]
     filter_wheel_seq = []
     for microscope_name in device_config.keys():
-        # camera
-        # delay_percent -> delay
         for device_name in required_devices:
             if device_name not in device_config[microscope_name]:
                 print(
@@ -991,9 +989,6 @@ def verify_configuration(manager, configuration):
                     f"No {device_name} defined for microscope {microscope_name}"
                 )
         camera_config = device_config[microscope_name]["camera"]
-        if "delay" not in camera_config.keys():
-            camera_config["delay"] = camera_config.get("delay_percent", 2)
-
         try:
             channel_count = max(channel_count, camera_config.get("count", 5))
         except TypeError:

--- a/src/navigate/config/configuration.yaml
+++ b/src/navigate/config/configuration.yaml
@@ -24,7 +24,6 @@ microscopes:
         serial_number: 302158
         camera_connection: PMPCIECam00 #Photometrics only
       defect_correct_mode: 2.0
-      delay: 1.0 #ms
       settle_down: 0.0 #ms
       flip_x: False
       flip_y: False
@@ -219,7 +218,6 @@ microscopes:
         serial_number: 302352
         camera_connection: PMPCIECam00 #Photometrics only
       defect_correct_mode: 2.0
-      delay: 1.0 #ms
       settle_down: 0 #ms
       flip_x: False
       flip_y: False

--- a/src/navigate/config/synthetic_configuration.yaml
+++ b/src/navigate/config/synthetic_configuration.yaml
@@ -57,7 +57,6 @@ microscopes:
         serial_number: 302352
       lightsheet_rolling_shutter_width: 608
       defect_correct_mode: 2.0 # Off: 1.0, On: 2.0
-      delay_percent: 10
       pulse_percent: 1
       x_pixels_step: 4
       y_pixels_step: 4

--- a/src/navigate/config/waveform_constants.yml
+++ b/src/navigate/config/waveform_constants.yml
@@ -214,6 +214,7 @@
         }
     },
     "other_constants": {
-        "remote_focus_settle_duration": "10"
+        "remote_focus_settle_duration": "10",
+        "camera_delay": "1.0"
     }
 }

--- a/src/navigate/model/devices/daq/base.py
+++ b/src/navigate/model/devices/daq/base.py
@@ -68,9 +68,6 @@ class DAQBase(ABC):
         #: dict: Dictionary of configuration parameters
         self.configuration = configuration
 
-        #: dict: Dictionary of waveform constants
-        self.waveform_constants = self.configuration["waveform_constants"]
-
         #: str: Name of the active microscope
         self.microscope_name = self.configuration["experiment"]["MicroscopeState"][
             "microscope_name"
@@ -113,6 +110,11 @@ class DAQBase(ABC):
     def __str__(self) -> str:
         """Returns the string representation of the DAQBase class"""
         return "DAQBase"
+
+    @property
+    def waveform_constants(self) -> dict[str, Any]:
+        """Return the currently loaded waveform constants."""
+        return self.configuration["waveform_constants"]
 
     @abstractmethod
     def stop_acquisition(self) -> None:

--- a/src/navigate/model/devices/galvo/base.py
+++ b/src/navigate/model/devices/galvo/base.py
@@ -110,14 +110,6 @@ class GalvoBase(ABC):
         #: float: Sweep time.
         self.sweep_time = 0
 
-        #: float: Camera delay
-        self.camera_delay = (
-            configuration["configuration"]["microscopes"][microscope_name]["camera"][
-                "delay"
-            ]
-            / 1000
-        )
-
         #: float: Galvo max voltage.
         self.galvo_max_voltage = self.device_config["hardware"]["max"]
 
@@ -138,6 +130,18 @@ class GalvoBase(ABC):
     def __del__(self):
         """Destructor"""
         pass
+
+    @property
+    def camera_delay(self) -> float:
+        """Return the current camera delay from waveform constants, in seconds."""
+        return (
+            float(
+                self.configuration["waveform_constants"]["other_constants"][
+                    "camera_delay"
+                ]
+            )
+            / 1000
+        )
 
     @abstractmethod
     def adjust(

--- a/src/navigate/model/devices/remote_focus/base.py
+++ b/src/navigate/model/devices/remote_focus/base.py
@@ -96,14 +96,6 @@ class RemoteFocusBase(ABC):
         #: float: Sweep time of the DAQ.
         self.sweep_time = 0
 
-        #: float: Camera delay percent.
-        self.camera_delay = (
-            configuration["configuration"]["microscopes"][microscope_name]["camera"][
-                "delay"
-            ]
-            / 1000
-        )
-
         # Waveform Parameters
         #: float: Remote focus max voltage.
         self.remote_focus_max_voltage = self.device_config["hardware"]["max"]
@@ -121,6 +113,18 @@ class RemoteFocusBase(ABC):
     def __del__(self) -> None:
         """Destructor"""
         pass
+
+    @property
+    def camera_delay(self) -> float:
+        """Return the current camera delay from waveform constants, in seconds."""
+        return (
+            float(
+                self.configuration["waveform_constants"]["other_constants"][
+                    "camera_delay"
+                ]
+            )
+            / 1000
+        )
 
     @abstractmethod
     def move(

--- a/src/navigate/model/devices/stage/ni.py
+++ b/src/navigate/model/devices/stage/ni.py
@@ -138,14 +138,6 @@ class NIStage(StageBase, NIDevice):
             microscope_name
         ]["daq"]["trigger_source"]
 
-        #: float: Percent of the camera delay.
-        self.camera_delay = (
-            configuration["configuration"]["microscopes"][microscope_name]["camera"][
-                "delay"
-            ]
-            / 1000
-        )
-
         #: float: Sample rate of the DAQ.
         self.sample_rate = self.configuration["configuration"]["microscopes"][
             self.microscope_name
@@ -164,6 +156,18 @@ class NIStage(StageBase, NIDevice):
         self.ao_task = None
 
         self.switch_mode("normal")
+
+    @property
+    def camera_delay(self) -> float:
+        """Return the current camera delay from waveform constants, in seconds."""
+        return (
+            float(
+                self.configuration["waveform_constants"]["other_constants"][
+                    "camera_delay"
+                ]
+            )
+            / 1000
+        )
 
     # for stacking, we could have 2 axis here or not, y is for tiling, not necessary
     def report_position(self) -> dict[str, float]:

--- a/src/navigate/model/microscope.py
+++ b/src/navigate/model/microscope.py
@@ -670,10 +670,7 @@ class Microscope:
         logger.info(f"Waveform constants: {repr(dict(waveform_constants))}")
 
         camera_delay = (
-            self.configuration["configuration"]["microscopes"][self.microscope_name][
-                "camera"
-            ]["delay"]
-            / 1000
+            float(waveform_constants["other_constants"]["camera_delay"]) / 1000
         )
         camera_settle_duration = (
             self.configuration["configuration"]["microscopes"][self.microscope_name][

--- a/test/config/test_config.py
+++ b/test/config/test_config.py
@@ -304,6 +304,29 @@ class TestVerifyConfiguration(unittest.TestCase):
                     filter_wheel_name == temp
                 ), "filter wheel names should be the same for all microscopes"
 
+    def test_verify_waveform_constants_uses_legacy_camera_delay_as_default(self):
+        configuration = config.load_configs(
+            self.manager,
+            configuration=os.path.join(self.config_path, "configuration.yaml"),
+            waveform_constants=os.path.join(
+                self.config_path, "waveform_constants.yml"
+            ),
+        )
+        microscope_name = list(
+            configuration["configuration"]["microscopes"].keys()
+        )[0]
+        configuration["configuration"]["microscopes"][microscope_name]["camera"][
+            "delay"
+        ] = "7.5"
+        del configuration["waveform_constants"]["other_constants"]["camera_delay"]
+
+        config.verify_waveform_constants(self.manager, configuration)
+
+        assert (
+            configuration["waveform_constants"]["other_constants"]["camera_delay"]
+            == "7.5"
+        )
+
     def test_verify_configuration_with_no_filterwheel(self):
         configuration = config.load_configs(
             self.manager,

--- a/test/config/test_config.py
+++ b/test/config/test_config.py
@@ -308,16 +308,15 @@ class TestVerifyConfiguration(unittest.TestCase):
         configuration = config.load_configs(
             self.manager,
             configuration=os.path.join(self.config_path, "configuration.yaml"),
-            waveform_constants=os.path.join(
-                self.config_path, "waveform_constants.yml"
-            ),
+            waveform_constants=os.path.join(self.config_path, "waveform_constants.yml"),
         )
-        microscope_name = list(
-            configuration["configuration"]["microscopes"].keys()
-        )[0]
+        microscope_name = list(configuration["configuration"]["microscopes"].keys())[0]
         configuration["configuration"]["microscopes"][microscope_name]["camera"][
             "delay"
         ] = "7.5"
+        configuration["configuration"]["microscopes"][microscope_name]["camera"][
+            "delay_percent"
+        ] = "12.5"
         del configuration["waveform_constants"]["other_constants"]["camera_delay"]
 
         config.verify_waveform_constants(self.manager, configuration)
@@ -325,6 +324,27 @@ class TestVerifyConfiguration(unittest.TestCase):
         assert (
             configuration["waveform_constants"]["other_constants"]["camera_delay"]
             == "7.5"
+        )
+
+    def test_verify_waveform_constants_uses_legacy_delay_percent_as_default(self):
+        configuration = config.load_configs(
+            self.manager,
+            configuration=os.path.join(self.config_path, "configuration.yaml"),
+            waveform_constants=os.path.join(self.config_path, "waveform_constants.yml"),
+        )
+        microscope_name = list(configuration["configuration"]["microscopes"].keys())[0]
+        camera_config = configuration["configuration"]["microscopes"][microscope_name][
+            "camera"
+        ]
+        camera_config.pop("delay", None)
+        camera_config["delay_percent"] = "10"
+        del configuration["waveform_constants"]["other_constants"]["camera_delay"]
+
+        config.verify_waveform_constants(self.manager, configuration)
+
+        assert (
+            configuration["waveform_constants"]["other_constants"]["camera_delay"]
+            == "10"
         )
 
     def test_verify_configuration_with_no_filterwheel(self):
@@ -968,9 +988,7 @@ class TestVerifyExperimentConfig(unittest.TestCase):
 
         config.verify_experiment_config(self.manager, configuration)
 
-        assert (
-            experiment["MicroscopeState"]["channels"]["channel_2"]["defocus"] == -2.5
-        )
+        assert experiment["MicroscopeState"]["channels"]["channel_2"]["defocus"] == -2.5
 
     def select_random_entries_from_list(self, parameter_list):
         n = random.randint(1, len(parameter_list))

--- a/test/config/test_configuration.py
+++ b/test/config/test_configuration.py
@@ -51,6 +51,12 @@ class TestConfiguration(unittest.TestCase):
         with open(yaml_path) as file:
             self.data = yaml.safe_load(file)
 
+        synthetic_yaml_path = os.path.join(
+            root_path, "src", "navigate", "config", "synthetic_configuration.yaml"
+        )
+        with open(synthetic_yaml_path) as file:
+            self.synthetic_data = yaml.safe_load(file)
+
         waveform_constants_path = os.path.join(
             root_path, "src", "navigate", "config", "waveform_constants.yml"
         )
@@ -188,6 +194,14 @@ class TestConfiguration(unittest.TestCase):
         self.assertEqual(
             self.waveform_constants["other_constants"]["camera_delay"], "1.0"
         )
+
+    def test_synthetic_camera_timing_uses_waveform_constants(self):
+        for microscope in self.synthetic_data["microscopes"].values():
+            camera = microscope.get("camera")
+            if camera is None:
+                continue
+            self.assertNotIn("delay", camera)
+            self.assertNotIn("delay_percent", camera)
 
     def daq_section(self, microscope, hardware_type):
         expected_daq_keys = [

--- a/test/config/test_configuration.py
+++ b/test/config/test_configuration.py
@@ -51,6 +51,12 @@ class TestConfiguration(unittest.TestCase):
         with open(yaml_path) as file:
             self.data = yaml.safe_load(file)
 
+        waveform_constants_path = os.path.join(
+            root_path, "src", "navigate", "config", "waveform_constants.yml"
+        )
+        with open(waveform_constants_path) as file:
+            self.waveform_constants = yaml.safe_load(file)
+
     def tearDown(self):
         pass
 
@@ -178,6 +184,11 @@ class TestConfiguration(unittest.TestCase):
                 else:
                     raise ValueError("Unexpected hardware type")
 
+    def test_waveform_constants_camera_delay(self):
+        self.assertEqual(
+            self.waveform_constants["other_constants"]["camera_delay"], "1.0"
+        )
+
     def daq_section(self, microscope, hardware_type):
         expected_daq_keys = [
             "hardware",
@@ -207,7 +218,6 @@ class TestConfiguration(unittest.TestCase):
         expected_keys = [
             "hardware",
             "defect_correct_mode",
-            "delay",
             "settle_down",
             "flip_x",
             "flip_y",

--- a/test/model/devices/daq/test_daq_base.py
+++ b/test/model/devices/daq/test_daq_base.py
@@ -70,6 +70,16 @@ def test_enable_microscope_updates_rate_and_delay():
     assert daq.camera_delay == 0.009
 
 
+def test_enable_microscope_reads_replaced_waveform_constants():
+    configuration = _build_configuration(camera_delay_ms=1)
+    daq = _ConcreteDAQ(configuration)
+    configuration["waveform_constants"] = {"other_constants": {"camera_delay": 7}}
+
+    daq.enable_microscope("ScopeA")
+
+    assert daq.camera_delay == 0.007
+
+
 def test_set_external_trigger_updates_trigger_mode():
     daq = _ConcreteDAQ(_build_configuration())
 

--- a/test/model/devices/daq/test_daq_ni.py
+++ b/test/model/devices/daq/test_daq_ni.py
@@ -801,6 +801,17 @@ def test_enable_microscope_switches_scope_and_laser_task(ni_module):
     assert new_switch_task.write_calls[0]["data"].item() is False
 
 
+def test_enable_microscope_reads_replaced_waveform_constants(ni_module):
+    module, _, _ = ni_module
+    configuration = _build_configuration()
+    daq = module.NIDAQ(configuration)
+    configuration["waveform_constants"] = {"other_constants": {"camera_delay": 11}}
+
+    daq.enable_microscope("ScopeA")
+
+    assert daq.camera_delay == pytest.approx(0.011)
+
+
 def test_enable_microscope_without_laser_switch_settings_is_noop(ni_module):
     module, _, _ = ni_module
     config = _build_configuration()

--- a/test/model/devices/galvo/test_galvo_asi.py
+++ b/test/model/devices/galvo/test_galvo_asi.py
@@ -111,7 +111,6 @@ def build_asi_configuration(
                         "sample_rate": 100,
                         "trigger_source": "/Dev1/PFI0",
                     },
-                    "camera": {"delay": 0},
                 }
             }
         },
@@ -126,7 +125,10 @@ def build_asi_configuration(
             }
         },
         "waveform_constants": {
-            "other_constants": {"galvo_factor": galvo_factor},
+            "other_constants": {
+                "camera_delay": "0",
+                "galvo_factor": galvo_factor,
+            },
             "galvo_constants": {
                 "Galvo 0": {
                     "TestScope": {

--- a/test/model/devices/galvo/test_galvo_base.py
+++ b/test/model/devices/galvo/test_galvo_base.py
@@ -85,7 +85,6 @@ def build_base_configuration(
                         "sample_rate": 100,
                         "trigger_source": "/Dev1/PFI0",
                     },
-                    "camera": {"delay": 0},
                 }
             }
         },
@@ -100,7 +99,10 @@ def build_base_configuration(
             }
         },
         "waveform_constants": {
-            "other_constants": {"galvo_factor": galvo_factor},
+            "other_constants": {
+                "camera_delay": "0",
+                "galvo_factor": galvo_factor,
+            },
             "galvo_constants": {
                 "Galvo 0": {"TestScope": {"1x": galvo_parameters}},
             },
@@ -238,9 +240,11 @@ def test_adjust_pulse_waveform_respects_camera_delay_and_clears_final_sample():
         min_voltage=-10,
         channel_2_selected=False,
     )
-    config["configuration"]["microscopes"]["TestScope"]["camera"]["delay"] = 10
+    config["waveform_constants"]["other_constants"]["camera_delay"] = "10"
     config["configuration"]["microscopes"]["TestScope"]["daq"]["sample_rate"] = 1000
+    waveform_constants = config.pop("waveform_constants")
     galvo = build_synthetic_galvo(config)
+    config["waveform_constants"] = waveform_constants
 
     waveforms = galvo.adjust(
         exposure_times={"channel_1": 0.2},

--- a/test/model/devices/galvo/test_galvo_ni.py
+++ b/test/model/devices/galvo/test_galvo_ni.py
@@ -61,7 +61,6 @@ def build_ni_configuration():
                         "sample_rate": 100,
                         "trigger_source": "/Dev1/PFI0",
                     },
-                    "camera": {"delay": 0},
                 }
             }
         },
@@ -75,7 +74,7 @@ def build_ni_configuration():
             }
         },
         "waveform_constants": {
-            "other_constants": {"galvo_factor": "none"},
+            "other_constants": {"camera_delay": "0", "galvo_factor": "none"},
             "galvo_constants": {
                 "Galvo 0": {
                     "TestScope": {

--- a/test/model/devices/remote_focus/test_rf_asi.py
+++ b/test/model/devices/remote_focus/test_rf_asi.py
@@ -58,7 +58,6 @@ def _build_config(sensor_mode="Widefield", readout_direction="Top-to-Bottom"):
                         }
                     },
                     "daq": {"sample_rate": 10, "trigger_source": "PFI1"},
-                    "camera": {"delay": 5},
                 }
             }
         },
@@ -80,6 +79,7 @@ def _build_config(sensor_mode="Widefield", readout_direction="Top-to-Bottom"):
         },
         "waveform_constants": {
             "other_constants": {
+                "camera_delay": "5",
                 "remote_focus_ramp_falling": "17.5",
                 "remote_focus_delay": "0",
                 "percent_smoothing": "0",

--- a/test/model/devices/remote_focus/test_rf_base_unit.py
+++ b/test/model/devices/remote_focus/test_rf_base_unit.py
@@ -46,7 +46,6 @@ def _build_config(
                         }
                     },
                     "daq": {"sample_rate": 10, "trigger_source": "PFI1"},
-                    "camera": {"delay": 5},
                 }
             }
         },
@@ -68,6 +67,7 @@ def _build_config(
         },
         "waveform_constants": {
             "other_constants": {
+                "camera_delay": "5",
                 "remote_focus_ramp_falling": "20",
                 "remote_focus_delay": "10",
                 "percent_smoothing": str(percent_smoothing),
@@ -100,7 +100,9 @@ def test_adjust_ramp_branch_with_smoothing_and_clipping(base_module, monkeypatch
     laser_constants["amplitude"] = "-"
     laser_constants["offset"] = "."
 
+    waveform_constants = config.pop("waveform_constants")
     rf = _make_remote_focus(base_module, config)
+    rf.configuration["waveform_constants"] = waveform_constants
     rf.waveform_dict = {"stale_key": np.array([0.0])}
 
     ramp_kwargs = {}

--- a/test/model/devices/remote_focus/test_rf_ni_unit.py
+++ b/test/model/devices/remote_focus/test_rf_ni_unit.py
@@ -52,7 +52,6 @@ def ni_config():
                 "TestScope": {
                     "remote_focus": {"hardware": {"channel": "Dev7/ao3"}},
                     "daq": {"sample_rate": 10, "trigger_source": "PFI1"},
-                    "camera": {"delay": 5},
                 }
             }
         }

--- a/test/model/devices/stages/test_stage_ni.py
+++ b/test/model/devices/stages/test_stage_ni.py
@@ -95,6 +95,22 @@ class TestNIStage:
             getattr(stage, "get_abs_position")
         )
 
+    @patch("nidaqmx.Task")
+    def test_camera_delay_reads_waveform_constants(self, *args):
+        camera_config = self.configuration["configuration"]["microscopes"][
+            self.microscope_name
+        ]["camera"]
+        camera_config.pop("delay", None)
+        self.configuration["waveform_constants"]["other_constants"][
+            "camera_delay"
+        ] = "7.5"
+        waveform_constants = self.configuration.pop("waveform_constants")
+
+        stage = NIStage(self.microscope_name, self.daq, self.configuration)
+        self.configuration["waveform_constants"] = waveform_constants
+
+        assert stage.camera_delay == pytest.approx(0.0075)
+
     @pytest.mark.parametrize("axes", [(["x"]), (["y"]), (["f"])])
     def test_initialize_stage(self, axes):
         self.stage_configuration["stage"]["hardware"]["axes"] = axes

--- a/test/model/dummy.py
+++ b/test/model/dummy.py
@@ -560,10 +560,7 @@ class DummyMicroscope:
         microscope_state = self.configuration["experiment"]["MicroscopeState"]
         waveform_constants = self.configuration["waveform_constants"]
         camera_delay = (
-            self.configuration["configuration"]["microscopes"][self.microscope_name][
-                "camera"
-            ]["delay"]
-            / 1000
+            float(waveform_constants["other_constants"]["camera_delay"]) / 1000
         )
         camera_settle_duration = (
             self.configuration["configuration"]["microscopes"][self.microscope_name][


### PR DESCRIPTION
## Summary

- Remove `camera.delay` from the bundled hardware configuration.
- Store the default camera delay in `waveform_constants.other_constants.camera_delay`.
- Resolve camera delay at waveform-generation time for microscope, galvo, remote-focus, and NI-stage timing.
- Preserve compatibility with legacy configurations by using `camera.delay` as the default only when the waveform parameter is missing or invalid.
- Add regression coverage for legacy fallback behavior and lazy waveform-parameter access.