### PR TITLE
Improve configurator defaults and hardware type normalization

### DIFF
--- a/src/navigate/config/preload_rules/configuration.py
+++ b/src/navigate/config/preload_rules/configuration.py
@@ -1355,7 +1355,12 @@ def _normalize_setting_value(value: Any, spec: SettingSpec, *, name: str = "") -
 
 def _allows_structured_setting_value(name: str, value: Any) -> bool:
     """Return whether a structured value is valid for a legacy text-edit schema."""
-    if name in {"axes", "axes_mapping", "joystick_axes"}:
+    if name in {
+        "axes",
+        "axes_mapping",
+        "feedback_alignment",
+        "joystick_axes",
+    }:
         return isinstance(value, (list, ListProxy))
     if name == "coupled_axes":
         return isinstance(value, (dict, DictProxy))

--- a/src/navigate/config/preload_rules/configuration.py
+++ b/src/navigate/config/preload_rules/configuration.py
@@ -211,9 +211,9 @@ def normalize_laser_hardware(context: PreloadContext) -> None:
                 if isinstance(power_hardware, (dict, DictProxy))
                 else "Synthetic"
             )
-            if onoff_type != "Synthetic":
+            if not _is_synthetic_type(onoff_type):
                 hardware_config = dict(onoff_hardware)
-            elif power_type != "Synthetic":
+            elif not _is_synthetic_type(power_type):
                 hardware_config = dict(power_hardware)
             else:
                 hardware_config = {"type": "Synthetic"}
@@ -854,6 +854,12 @@ def normalize_device_type_names(context: PreloadContext) -> None:
                 continue
             current_type = hardware.get("type")
             normalized_type = canonical_device_type(category, current_type)
+            if (
+                category == "daq"
+                and isinstance(normalized_type, str)
+                and "." in normalized_type
+            ):
+                normalized_type = normalized_type.split(".")[1]
             if normalized_type is None or normalized_type == current_type:
                 continue
             hardware["type"] = normalized_type
@@ -952,7 +958,7 @@ def _iter_reference_devices(microscope_config) -> list[tuple[str, Any, int]]:
 def _iter_type_devices(microscope_config) -> list[tuple[str, Any, int]]:
     """Return top-level device dictionaries whose hardware type can be normalized."""
     devices = []
-    for category in DEVICE_REFERENCE_FIELDS:
+    for category in ("daq", *DEVICE_REFERENCE_FIELDS):
         if category == "stage":
             continue
         if category not in microscope_config:

--- a/src/navigate/controller/configurator.py
+++ b/src/navigate/controller/configurator.py
@@ -163,8 +163,12 @@ class Configurator:
         self.view.device_info_frame.horizontal_scrollbar.config(
             command=self.view.device_info_frame.settings_canvas.xview
         )
+        self.view.device_info_frame.vertical_scrollbar.config(
+            command=self.view.device_info_frame.settings_canvas.yview
+        )
         self.view.device_info_frame.settings_canvas.config(
-            xscrollcommand=self.view.device_info_frame.horizontal_scrollbar.set
+            xscrollcommand=self.view.device_info_frame.horizontal_scrollbar.set,
+            yscrollcommand=self.view.device_info_frame.vertical_scrollbar.set,
         )
 
     def on_cancel(self) -> None:
@@ -1730,7 +1734,7 @@ class Configurator:
         )
 
     def update_scrollregion(self, _event: tk.Event) -> None:
-        """Update horizontal scrolling for dynamically created setting widgets."""
+        """Update scrolling for dynamically created setting widgets."""
         canvas = self.view.device_info_frame.settings_canvas
         canvas.configure(scrollregion=canvas.bbox(tk.ALL))
 

--- a/src/navigate/controller/configurator.py
+++ b/src/navigate/controller/configurator.py
@@ -38,6 +38,7 @@ from typing import Optional
 
 import yaml
 
+from navigate.config.config import get_navigate_path
 from navigate.config.configuration_schema import (
     CollectionSpec,
     SettingSpec,
@@ -1088,7 +1089,9 @@ class Configurator:
             dialog_options["initialdir"] = str(self.last_configuration_path.parent)
             dialog_options["initialfile"] = self.last_configuration_path.name
         else:
-            dialog_options["initialfile"] = "new-config.yaml"
+            base = Path(get_navigate_path())
+            dialog_options["initialdir"] = str(base.joinpath("config"))
+            dialog_options["initialfile"] = "configuration.yaml"
         filename = filedialog.asksaveasfilename(**dialog_options)
         if not filename:
             return

--- a/src/navigate/controller/configurator.py
+++ b/src/navigate/controller/configurator.py
@@ -34,7 +34,7 @@ import re
 import tkinter as tk
 from pathlib import Path
 from tkinter import filedialog, messagebox, ttk
-from typing import Optional
+from typing import Optional, Union
 
 import yaml
 
@@ -942,6 +942,10 @@ class Configurator:
                 "axes_mapping",
             }:
                 device["hardware"][name] = InlineYamlList(self.parse_stage_axes(value))
+            elif category == "stage" and name == "feedback_alignment":
+                device["hardware"][name] = InlineYamlList(
+                    self.parse_stage_feedback_alignment(value)
+                )
             elif category == "stage" and name == "joystick_axes":
                 device[name] = InlineYamlList(self.parse_stage_axes(value))
             elif category == "stage" and name == "coupled_axes":
@@ -1366,6 +1370,23 @@ class Configurator:
             for axis in re.split(r"[\s,]+", str(value).strip().strip("[]"))
             if axis.strip("'\"")
         ]
+
+    @classmethod
+    def parse_stage_feedback_alignment(cls, value: str) -> list[Union[int, float, str]]:
+        """Convert ASI feedback alignment into a list without stringifying numbers."""
+        return [cls.parse_numeric_token(token) for token in cls.parse_stage_axes(value)]
+
+    @staticmethod
+    def parse_numeric_token(value: object) -> Union[int, float, str]:
+        """Return an int or float for numeric text; otherwise return stripped text."""
+        token = str(value).strip().strip("'\"")
+        if re.fullmatch(r"[-+]?\d+", token):
+            return int(token)
+        if re.fullmatch(r"[-+]?(?:\d+\.\d*|\.\d+)(?:[eE][-+]?\d+)?", token):
+            return float(token)
+        if re.fullmatch(r"[-+]?\d+[eE][-+]?\d+", token):
+            return float(token)
+        return token
 
     @staticmethod
     def parse_coupled_axes(value: str) -> dict[str, str]:

--- a/src/navigate/controller/controller.py
+++ b/src/navigate/controller/controller.py
@@ -2069,12 +2069,14 @@ class Controller:
 
     def _restore_camera_trigger_setting(self):
         """Restore the camera trigger setting."""
-        for microscope_name in self.configuration.get("experiment", {}).get(
-            "CameraParameters", {}
+        for microscope_name in (
+            self.configuration.get("configuration", {}).get("microscopes", {}).keys()
         ):
             if (
                 "trigger_source_backup"
-                in self.configuration["experiment"]["CameraParameters"][microscope_name]
+                in self.configuration["experiment"]["CameraParameters"][
+                    microscope_name
+                ].keys()
             ):
                 if (
                     self.configuration["experiment"]["CameraParameters"][

--- a/src/navigate/model/devices/daq/ni.py
+++ b/src/navigate/model/devices/daq/ni.py
@@ -84,7 +84,7 @@ class NIDAQ(DAQBase):
         ),
         "laser_port_switcher": SettingSpec(
             str,
-            default="PXI6733/port0/line0",
+            default="",
             label="Laser Port Switcher",
             help_text="Digital output line used to switch laser ports.",
             required=False,

--- a/src/navigate/model/devices/laser/asi.py
+++ b/src/navigate/model/devices/laser/asi.py
@@ -32,7 +32,7 @@
 
 #  Standard Library Imports
 import logging
-from typing import Any
+from typing import Any, Union
 
 # Third Party Imports
 
@@ -269,6 +269,21 @@ class ASILaser(LaserBase, SerialDevice):
         """Destructor for the ASILaser class."""
         self.close()
 
-    def _is_asi_type(self, hardware_type: str) -> bool:
-        """Check if the hardware type is ASI type."""
-        return hardware_type.lower() in ("asi", "asi.asi")
+    def _is_asi_type(self, hardware_type: Union[str, None]) -> bool:
+        """Check if the hardware type is ASI type.
+
+        Parameters
+        ----------
+        hardware_type : Union[str, None]
+            The hardware type to check.
+
+        Returns
+        -------
+        bool
+            True if the hardware type is ASI type, False otherwise.
+        """
+        return (
+            hardware_type
+            and isinstance(hardware_type, str)
+            and hardware_type.lower() in ("asi", "asi.asi")
+        )

--- a/src/navigate/model/devices/laser/asi.py
+++ b/src/navigate/model/devices/laser/asi.py
@@ -108,11 +108,11 @@ class ASILaser(LaserBase, SerialDevice):
             digital = digital.upper()
 
         # Determine modulation type
-        if analog == "ASI" and digital == "ASI":
+        if self._is_asi_type(analog) and self._is_asi_type(digital):
             modulation_type = "mixed"
-        elif analog == "ASI":
+        elif self._is_asi_type(analog):
             modulation_type = "analog"
-        elif digital == "ASI":
+        elif self._is_asi_type(digital):
             modulation_type = "digital"
         else:
             raise ValueError("Laser modulation type not recognized.")
@@ -268,3 +268,7 @@ class ASILaser(LaserBase, SerialDevice):
     def __del__(self):
         """Destructor for the ASILaser class."""
         self.close()
+
+    def _is_asi_type(self, hardware_type: str) -> bool:
+        """Check if the hardware type is ASI type."""
+        return hardware_type.lower() in ("asi", "asi.asi")

--- a/src/navigate/model/devices/laser/ni.py
+++ b/src/navigate/model/devices/laser/ni.py
@@ -33,7 +33,7 @@
 # Standard Library Imports
 import logging
 import traceback
-from typing import Any
+from typing import Any, Union
 
 # Third Party Imports
 import nidaqmx
@@ -287,6 +287,21 @@ class NILaser(LaserBase, NIDevice):
             except Exception:
                 logger.exception(f"Error stopping task: {traceback.format_exc()}")
 
-    def _is_ni_type(self, hardware_type: str) -> bool:
-        """Check if the hardware type is NI type."""
-        return hardware_type.lower() in ("ni", "ni.ni")
+    def _is_ni_type(self, hardware_type: Union[str, None]) -> bool:
+        """Check if the hardware type is NI type.
+
+        Parameters
+        ----------
+        hardware_type : Union[str, None]
+            The hardware type to check.
+
+        Returns
+        -------
+        bool
+            True if the hardware type is NI type, False otherwise.
+        """
+        return (
+            hardware_type
+            and isinstance(hardware_type, str)
+            and hardware_type.lower() in ("ni", "ni.ni")
+        )

--- a/src/navigate/model/devices/laser/ni.py
+++ b/src/navigate/model/devices/laser/ni.py
@@ -103,11 +103,11 @@ class NILaser(LaserBase, NIDevice):
             "laser"
         ][device_id]["onoff"]["hardware"].get("type", None)
 
-        if analog == "NI" and digital == "NI":
+        if self._is_ni_type(analog) and self._is_ni_type(digital):
             modulation_type = "mixed"
-        elif analog == "NI":
+        elif self._is_ni_type(analog):
             modulation_type = "analog"
-        elif digital == "NI":
+        elif self._is_ni_type(digital):
             modulation_type = "digital"
         else:
             raise ValueError("Laser modulation type not recognized.")
@@ -286,3 +286,7 @@ class NILaser(LaserBase, NIDevice):
                 self.laser_do_task.close()
             except Exception:
                 logger.exception(f"Error stopping task: {traceback.format_exc()}")
+
+    def _is_ni_type(self, hardware_type: str) -> bool:
+        """Check if the hardware type is NI type."""
+        return hardware_type.lower() in ("ni", "ni.ni")

--- a/src/navigate/view/configurator_application_window.py
+++ b/src/navigate/view/configurator_application_window.py
@@ -216,7 +216,7 @@ class DeviceInfoFrame(ttk.LabelFrame):
             row=2,
             column=0,
             sticky=tk.NSEW,
-            padx=get_theme_space_px(3),
+            padx=get_theme_padding_px((3, 0)),
             pady=get_theme_padding_px((0, 3)),
         )
         self.settings_frame = ttk.Frame(self.settings_canvas)
@@ -224,6 +224,14 @@ class DeviceInfoFrame(ttk.LabelFrame):
         self.settings_frame.columnconfigure(1, weight=1, minsize=160)
         self.settings_window = self.settings_canvas.create_window(
             (0, 0), anchor=tk.NW, window=self.settings_frame
+        )
+        self.vertical_scrollbar = ttk.Scrollbar(self, orient=tk.VERTICAL)
+        self.vertical_scrollbar.grid(
+            row=2,
+            column=1,
+            sticky=tk.NS,
+            padx=get_theme_padding_px((0, 3)),
+            pady=get_theme_padding_px((0, 3)),
         )
         self.horizontal_scrollbar = ttk.Scrollbar(self, orient=tk.HORIZONTAL)
         self.horizontal_scrollbar.grid(

--- a/src/navigate/view/configurator_application_window.py
+++ b/src/navigate/view/configurator_application_window.py
@@ -32,6 +32,7 @@
 import tkinter as tk
 from tkinter import ttk
 from typing import Optional
+from pathlib import Path
 
 # Local Imports
 from navigate.view.theme import (
@@ -46,12 +47,20 @@ class ConfigurationAssistantWindow(ttk.Frame):
 
     def __init__(self, root: tk.Tk, *args, **kwargs) -> None:
         self.root = root
-        self.root.title("New Configuration Assistant")
+        self.root.title("NavigateConfiguration Assistant")
         window_width, window_height = 1100, 720
         screen_width = self.root.winfo_screenwidth()
         screen_height = self.root.winfo_screenheight()
         position_x = max(0, (screen_width - window_width) // 2)
         position_y = max(0, (screen_height - window_height) // 2)
+
+        # keep icons relative to view directory structure
+        view_directory = Path(__file__).resolve().parent
+        try:
+            photo_image = view_directory.joinpath("icon", "mic.png")
+            self.root.iconphoto(True, tk.PhotoImage(file=photo_image))
+        except tk.TclError:
+            pass
         self.root.geometry(f"{window_width}x{window_height}+{position_x}+{position_y}")
         self.root.minsize(800, 500)
         self.root.rowconfigure(0, weight=1)

--- a/src/navigate/view/configurator_application_window.py
+++ b/src/navigate/view/configurator_application_window.py
@@ -47,7 +47,7 @@ class ConfigurationAssistantWindow(ttk.Frame):
 
     def __init__(self, root: tk.Tk, *args, **kwargs) -> None:
         self.root = root
-        self.root.title("NavigateConfiguration Assistant")
+        self.root.title("Navigate Configuration Assistant")
         window_width, window_height = 1100, 720
         screen_width = self.root.winfo_screenwidth()
         screen_height = self.root.winfo_screenheight()

--- a/test/config/test_preload.py
+++ b/test/config/test_preload.py
@@ -16,7 +16,10 @@ from navigate.config.preload import (
     _log_report,
     preload_configuration,
 )
-from navigate.config.preload_rules.configuration import _default_reference_value
+from navigate.config.preload_rules.configuration import (
+    _allows_structured_setting_value,
+    _default_reference_value,
+)
 from navigate.config.preload_rules.positions import validate_positions
 from navigate.config.configuration_schema import SettingSpec
 
@@ -55,6 +58,17 @@ def test_preload_warning_and_fatal_logs_are_wrapped_with_separators(caplog):
         f"{separator}\nPreload issue fatal.path: fatal message\n{separator}"
         in caplog.text
     )
+
+
+def test_preload_allows_stage_list_backed_text_settings():
+    """Stage list settings are valid structured values for legacy text fields."""
+    for name in (
+        "axes",
+        "axes_mapping",
+        "feedback_alignment",
+        "joystick_axes",
+    ):
+        assert _allows_structured_setting_value(name, ["x"])
 
 
 def test_preload_keeps_loaded_sections_as_shared_dicts(loaded_configuration):

--- a/test/config/test_preload.py
+++ b/test/config/test_preload.py
@@ -965,6 +965,27 @@ def test_preload_normalizes_device_types_before_reference_check(loaded_configura
     assert any(change.rule == "device-type-normalized" for change in report.changes)
 
 
+@pytest.mark.parametrize(
+    "raw_type,expected",
+    [
+        ("ni.NI", "NI"),
+        ("asi.ASI", "ASI"),
+        ("synthetic.Synthetic", "Synthetic"),
+    ],
+)
+def test_preload_normalizes_prefixed_daq_type_to_startup_token(
+    loaded_configuration, raw_type, expected
+):
+    manager, configuration = loaded_configuration
+    microscope = configuration["configuration"]["microscopes"]["Mesoscale"]
+    microscope["daq"]["hardware"]["type"] = raw_type
+
+    report = preload_configuration(manager, configuration)
+
+    assert microscope["daq"]["hardware"]["type"] == expected
+    assert any(change.rule == "device-type-normalized" for change in report.changes)
+
+
 def test_preload_silently_adds_optional_reference_field(
     loaded_configuration, monkeypatch
 ):

--- a/test/controller/test_configurator.py
+++ b/test/controller/test_configurator.py
@@ -3,8 +3,14 @@
 
 """Regression tests for configuration-assistant serialization helpers."""
 
+import yaml
+
 from navigate.controller import configurator as configurator_module
-from navigate.controller.configurator import Configurator, InlineYamlList
+from navigate.controller.configurator import (
+    Configurator,
+    ConfiguratorYamlDumper,
+    InlineYamlList,
+)
 from navigate.config.configuration_schema import SettingSpec
 from navigate.model.devices.zoom.base import ZoomBase
 
@@ -376,3 +382,28 @@ def test_stage_shared_axes_load_as_text_values():
 
     assert settings["joystick_axes"] == "x, y, z"
     assert settings["coupled_axes"] == "x:x1, y:y1"
+
+
+def test_stage_feedback_alignment_round_trips_as_inline_yaml_list():
+    """ASI feedback alignment is saved with the same list behavior as axes."""
+    configurator = Configurator.__new__(Configurator)
+    configurator.get_connect_params = lambda *_: []
+    configurator.get_configuration_schema = lambda *_: {
+        "feedback_alignment": SettingSpec(str),
+    }
+
+    settings = configurator.settings_from_configuration(
+        "stage",
+        "asi",
+        "ASIStage",
+        {"hardware": {"feedback_alignment": [88, 99, 101]}},
+    )
+    device = configurator.device_configuration(
+        "stage", "asi", "ASIStage", settings
+    )
+    dumped = yaml.dump(device, Dumper=ConfiguratorYamlDumper, sort_keys=False)
+
+    assert settings["feedback_alignment"] == [88, 99, 101]
+    assert isinstance(device["hardware"]["feedback_alignment"], InlineYamlList)
+    assert device["hardware"]["feedback_alignment"] == [88, 99, 101]
+    assert "feedback_alignment: [88, 99, 101]" in dumped

--- a/test/controller/test_controller.py
+++ b/test/controller/test_controller.py
@@ -925,6 +925,7 @@ def test_execute_exit_saves_gui_configuration_to_loaded_path(tmp_path):
     controller.configuration = {
         name: {"name": name}
         for name in [
+            "configuration",
             "experiment",
             "multi_positions",
             "gui",
@@ -932,6 +933,12 @@ def test_execute_exit_saves_gui_configuration_to_loaded_path(tmp_path):
             "rest_api_config",
             "waveform_templates",
         ]
+    }
+    controller.configuration["configuration"]["microscopes"] = {
+        "Mesoscale": {},
+        "Synthetic Scope": {},
+        "Scope Without Backup": {},
+        "Scope With No Trigger": {},
     }
     controller.configuration["experiment"]["CameraParameters"] = {
         "Mesoscale": {
@@ -943,6 +950,10 @@ def test_execute_exit_saves_gui_configuration_to_loaded_path(tmp_path):
             "trigger_source_backup": "Internal",
         },
         "Scope Without Backup": {"trigger_source": "Software"},
+        "Scope With No Trigger": {
+            "trigger_source": "Software",
+            "trigger_source_backup": None,
+        },
     }
     controller.sloppy_stop = MagicMock()
     controller.update_experiment_setting = MagicMock()
@@ -969,6 +980,11 @@ def test_execute_exit_saves_gui_configuration_to_loaded_path(tmp_path):
     assert camera_parameters["Mesoscale"]["trigger_source"] == "External"
     assert camera_parameters["Synthetic Scope"]["trigger_source"] == "Internal"
     assert camera_parameters["Scope Without Backup"]["trigger_source"] == "Software"
+    assert "trigger_source" not in camera_parameters["Scope With No Trigger"]
+    assert all(
+        "trigger_source_backup" not in parameters
+        for parameters in camera_parameters.values()
+    )
 
 
 def test_execute_adaptive_optics(controller):

--- a/test/view/test_configurator_application_window.py
+++ b/test/view/test_configurator_application_window.py
@@ -30,6 +30,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import tkinter as tk
 from tkinter import ttk
 
 from navigate.view.custom_widgets.CollapsibleFrame import CollapsibleFrame
@@ -89,6 +90,21 @@ def test_configurator_window_uses_themed_spacing(tk_root):
     view.top_window.add_button.destroy()
     view.top_window.save_button.destroy()
     view.top_window.cancel_button.destroy()
+    view.destroy()
+
+
+def test_device_info_panel_has_vertical_scrollbar(tk_root):
+    view = ConfigurationAssistantWindow(tk_root)
+    tk_root.update_idletasks()
+
+    panel = view.device_info_frame
+
+    assert isinstance(panel.vertical_scrollbar, ttk.Scrollbar)
+    assert str(panel.vertical_scrollbar.cget("orient")) == tk.VERTICAL
+    assert int(panel.vertical_scrollbar.grid_info()["row"]) == 2
+    assert int(panel.vertical_scrollbar.grid_info()["column"]) == 1
+    assert str(panel.vertical_scrollbar.grid_info()["sticky"]).lower() == tk.NS
+
     view.destroy()
 
 


### PR DESCRIPTION
## Summary

- Update the configuration assistant UI with the Navigate title/icon and add vertical scrolling for device settings.
- Change new configuration saves to default to `config/configuration.yaml` under the Navigate path.
- Preserve ASI stage `feedback_alignment` values as inline YAML lists while keeping numeric values numeric.
- Normalize prefixed DAQ and laser hardware types such as `ni.NI` and `asi.ASI` for startup/configurator compatibility.
- Remove the default NI `laser_port_switcher` value so it is blank unless explicitly configured.
- Restore camera trigger backups based on configured microscopes.
